### PR TITLE
Re-use the version number information from Cabal.

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -52,6 +52,7 @@ Executable bnfc
     src/formats/c-sharp
     src/formats/f-sharp
   Other-modules:
+    Paths_BNFC,
     LexBNF,
     ParBNF,
     AbsBNF,

--- a/source/src/Main.hs
+++ b/source/src/Main.hs
@@ -50,10 +50,11 @@ import Data.Char
 import Data.List (elemIndex, foldl')
 import Control.Monad (when,unless)
 
-version = "2.6a"
+import Paths_BNFC ( version )
+import Data.Version ( showVersion )
 
 title = unlines [
-  "The BNF Converter, "++version, 
+  "The BNF Converter, "++showVersion version,
   "(c) Krasimir Angelov, Jean-Philippe Bernardy, Bjorn Bringert, Johan Broberg, Paul Callaghan, ",
   "    Markus Forsberg, Ola Frid, Peter Gammie, Patrik Jansson, ",
   "    Kristofer Johannisson, Antti-Juhani Kaijanaho, Ulf Norell, ",
@@ -68,7 +69,7 @@ main = do
 	  
   case xx of
     ["--numeric-version"] -> do
-      putStrLn version
+      putStrLn (showVersion version)
       exitSuccess
     [] -> printUsage
     _ | elem "-multi" xx -> do


### PR DESCRIPTION
The BNFC executable claimed to be version "2.6a" -- although the Cabal file
said that it would be version 2.6.0.3. This kind of mismatch can be avoided by
re-using the version number from the Paths_BNFC module which Cabal generates
during the build.

Furthermore, the version number "2.6a" is _illegal_ in Cabal. Cabal cannot
parse that string, which means that version 2.6.0.3 of the BNF Converter cannot
be used in Cabal-based builds. An attempt to refer to BNFC as a build tool
invariably ends with this the following message:

 | Warning: cannot determine version of /home/simons/.nix-profile/bin/bnfc :
 | "2.6a\n"
 | setup: The program BNFC version >=2.4 is required but the version of
 | /home/simons/.nix-profile/bin/bnfc could not be determined.

This patch avoids this kind of error.
