### PR TITLE
Fixed alex regex bug.

### DIFF
--- a/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
@@ -329,7 +329,12 @@ instance Print a => Print [a] where
   prt _ = prtList
 
 instance Print Char where
-  prt _ c = if isAlphaNum c then [[c]] else ['\\':[c]]
+  prt _ c = case c of
+             '\n' -> ["\\n"]
+             '\t' -> ["\\t"]
+             c | isAlphaNum c -> [[c]] 
+             c | isPrint c    -> ['\\':[c]]
+             c | otherwise    -> ['\\':show (ord c)]
   prtList s = map (concat . prt 0) s
 
 prPrec :: Int -> Int -> [String] -> [String]


### PR DESCRIPTION
I wrote this patch to address an issue with how bnfc treats \n and \t codes in regular expressions destined for alex to parse.

token Word        ( (char - [" \n\t=;<|'\"\"])+ ) ;

Given the above statement, bnfc will generates the following incorrect regular expression in the alex input file...

($u # [\  \
 \    \= \; < | \' \" \]) + { tok (\p s -> PT p (eitherResIdent (T_Word . share) s)) }

It would be better, if it generated this instead:
 ($u # [\  \n \t \= \; < | \' \" \]) + { tok (\p s -> PT p (eitherResIdent (T_Word . share) s)) }
