### PR TITLE
Added token support for OCaml.  Fixed an install bug in Makefile

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -1,3 +1,5 @@
+.PHONY: install
+
 all: build
 
 build:

--- a/source/src/BNFC/CF.hs
+++ b/source/src/BNFC/CF.hs
@@ -78,8 +78,8 @@ module BNFC.CF (
             listCat,
 	    catOfList,
 	    comments,       -- translates the pragmas into two list containing the s./m. comments
-            tokenPragmas,
-            tokenNames,
+            tokenPragmas,   -- get the user-defined regular expression tokens
+            tokenNames,     -- get the names of all user-defined tokens
 	    precCat,        -- get the precendence level of a Cat C1 => 1, C => 0
 	    precLevels,     -- get all precendence levels in the grammar, sorted in increasing order.
 	    precRule,       -- get the precendence level of the value category of a rule.


### PR DESCRIPTION
This patch adds support for user defined tokens in the OCaml backend.  This will close issue #56 on the tracker.
