### PR TITLE
Derive `Read` for newtype decls in Haskell backend

### DIFF
--- a/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
@@ -41,7 +41,7 @@ prData (cat,rules) =
 
 prSpecialData :: Bool -> CF -> Cat -> String
 prSpecialData byteStrings cf cat =
-  unwords ["newtype",cat,"=",cat,contentSpec byteStrings cf cat,"deriving (Eq,Ord,Show)"]
+  unwords ["newtype",cat,"=",cat,contentSpec byteStrings cf cat,"deriving (Eq,Ord,Read,Show)"]
 
 contentSpec :: Bool -> CF -> Cat -> String
 contentSpec byteStrings cf cat = if isPositionCat cf cat then "((Int,Int),"++stringType++")" else stringType


### PR DESCRIPTION
This relates to BNFC/bnfc#84 and comment https://github.com/BNFC/bnfc/pull/83#issuecomment-39684692. Currently the definition for Ident is:

```
newtype Ident = Ident String deriving (Eq,Ord,Show)
```

This commit changes this definition to:

```
newtype Ident = Ident String deriving (Eq,Ord,Read,Show)
```

This allows users to translate Ident's from one language to another,
e.g:

```
LangX.IdentExp ident -> LangY.IdentExp (read (show ident))
```

One caveat is that is that ther newtype definitions will also derive
Read, though I can't comment on the significance of this?
