### PR TITLE
fixes for lexer_initialize using yyreset()

### DIFF
--- a/source/src/BNFC/Backend/C/CFtoFlexC.hs
+++ b/source/src/BNFC/Backend/C/CFtoFlexC.hs
@@ -155,7 +155,7 @@ restOfFlex cf env = concat
      "<CHARESC>.      \t BEGIN CHAREND; yylval.char_ = yytext[0]; return _CHAR_;",
      "<CHAREND>\"'\"      \t BEGIN YYINITIAL;"
     ]
-   footer = "void initialize_lexer(FILE *inp) { yyin = inp; BEGIN YYINITIAL; }"
+   footer = "void initialize_lexer(FILE *inp) { yyrestart(inp); BEGIN YYINITIAL; }"
 
 lexComments :: ([(String, String)], [String]) -> String
 lexComments (m,s) =

--- a/source/src/BNFC/Backend/CPP/NoSTL/CFtoFlex.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL/CFtoFlex.hs
@@ -156,7 +156,7 @@ restOfFlex inPackage cf env = concat
     ]
    footer = unlines
     [
-     "int " ++ ns ++ "initialize_lexer(FILE *inp) { yyin = inp; BEGIN YYINITIAL; }",
+     "int " ++ ns ++ "initialize_lexer(FILE *inp) { yyrestart(inp); BEGIN YYINITIAL; }",
      "int yywrap(void) { return 1; }"
     ]
 


### PR DESCRIPTION
For C family parsers there is a bug in initialize lexer.

This bug manifests as follows:
1. I have two documents to be parsed, document A and document B
2. Individually Document A results in a failed parse, Document B (which happens to be "" - an empty string) results in a valid parse
3. When run one after one another Document B results in a failed parse instead of a valid parse due to the initial state of the lexer not being properly setup.

To fix it, this code:

```
void initialize_lexer(FILE *inp) { yyin = inp; BEGIN YYINITIAL; }
```

Should be replaced with:

```
void initialize_lexer(FILE *inp) { yyrestart(inp); BEGIN YYINITIAL; }
```
