### PR TITLE
Made changes to how comments are generated in alex,

### DIFF
--- a/source/src/BNFC/Backend/Haskell/CFtoAlex2.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAlex2.hs
@@ -223,9 +223,10 @@ restOfAlex shareMod shareStrings byteStrings cf = [
    lexComments (([l1,l2],[r1,r2]):xs,[]) = concat $
 					[
 					('\"':l1:l2:"\" ([$u # \\"), -- FIXME quotes or escape?
-					(l2:"] | \\"),
-					(r1:" [$u # \\"),
-					(r2:"])* (\""),
+					(r1:"] | \\"),
+					(r1:"+ [$u # [\\"),
+					(r1:" \\"),
+					(r2:"]])* (\""),
 					(r1:"\")+ \""),
 					(r2:"\" ; \n"),
 					lexComments (xs, [])

--- a/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
@@ -244,9 +244,10 @@ restOfAlex shareMod shareStrings byteStrings cf = [
    lexComments (([l1,l2],[r1,r2]):xs,[]) = concat $
 					[
 					('\"':l1:l2:"\" ([$u # \\"), -- FIXME quotes or escape?
-					(l2:"] | \\"),
-					(r1:" [$u # \\"),
-					(r2:"])* (\""),
+					(r1:"] | \\"),
+					(r1:"+ [$u # [\\"),
+					(r1:" \\"),
+					(r2:"]])* (\""),
 					(r1:"\")+ \""),
 					(r2:"\" ; \n"),
 					lexComments (xs, [])


### PR DESCRIPTION
I made a parser for a language and preexisting code did not go through the parser and this fixed it.

The fix is namely for C-style comments, where inside there are a lot of asterisks and these kinds of comments seems to be hard to parse in general. I haven't yet run that many tests and I figure I should send the patch further to see if this is a beginners mistake or not.
