### PR TITLE
Fix bug in Abs generation, the positions weren't recorded.

### DIFF
--- a/source/src/BNFC/CF.hs
+++ b/source/src/BNFC/CF.hs
@@ -647,7 +647,7 @@ precCF cf = length (precLevels cf) > 1
 
 -- | Does the category have a position stored in AST?
 isPositionCat :: CFG f -> Cat -> Bool
-isPositionCat cf cat =  or [b | TokenReg name b _ <- pragmasOfCF cf, Cat name == cat]
+isPositionCat cf cat =  or [b | TokenReg name b _ <- pragmasOfCF cf, TokenCat name == cat]
 
 -- | Grammar with permutation profile à la GF. AR 22/9/2004
 type CFP   = CFG FunP -- (Exts,[RuleP])


### PR DESCRIPTION
Commit `b0dc41f3a7b59c3a3eae1942f3ab879edefbfab4` broke the `position` command.  The reason for the breakage is that `isPositionCat` returns `False` with `TokenCat`s.

This fixes it, but I don't know what the intendent behaviour of `isPositionCat` is -- I looked at the source code very briefly.
