### PR TITLE
Added OBJS define to Makefiles that are produced

### DIFF
--- a/source/src/BNFC/Backend/C.hs
+++ b/source/src/BNFC/Backend/C.hs
@@ -61,28 +61,29 @@ makeC opts cf = do
 
 makefile :: String -> String -> String
 makefile name prefix =
-  (++) (unlines [ "CC = gcc",
-                  "CCFLAGS = -g -W -Wall", "",
-                  "FLEX = flex",
-                  "FLEX_OPTS = -P" ++ prefix, "",
-                  "BISON = bison",
-                  "BISON_OPTS = -t -p" ++ prefix, ""])
+  (unlines [ "CC = gcc",
+             "CCFLAGS = -g -W -Wall", "",
+             "FLEX = flex",
+             "FLEX_OPTS = -P" ++ prefix, "",
+             "BISON = bison",
+             "BISON_OPTS = -t -p" ++ prefix, "",
+             "OBJS = Absyn.o Lexer.o Parser.o Printer.o", ""] ++)
   $ Makefile.mkRule ".PHONY" ["clean", "distclean"]
     []
   $ Makefile.mkRule "all" [testName]
     []
   $ Makefile.mkRule "clean" []
     -- peteg: don't nuke what we generated - move that to the "vclean" target.
-    [ "rm -f *.o " ++ unwords [ name ++ e | e <- [".aux",".log",".pdf",""]] ]
-  $ Makefile.mkRule "distclean" ["clean"] -- FIXME
+    [ "rm -f *.o " ++ testName ++ " " ++ unwords
+      [ name ++ e | e <- [".aux", ".log", ".pdf",".dvi", ".ps", ""]] ]
+  $ Makefile.mkRule "distclean" ["clean"]
     [ "rm -f " ++ unwords
-      [ "Absyn.c", "Absyn.h", "Test.c", "Parser.c", "Parser.h", "Lexer.c"
-      , "Skeleton.c", "Skeleton.h", "Printer.c" ,"Printer.h"
-      , name ++ ".l " ++ name ++ ".y " ++ name ++ ".tex "
-      , testName, "Makefile" ]]
-  $ Makefile.mkRule testName ["Absyn.o", "Lexer.o", "Parser.o", "Printer.o", "Test.o"]
-    [ "@echo \"Linking test" ++ name ++ "...\""
-    , "${CC} ${CCFLAGS} *.o -o Test" ++ name ]
+      [ "Absyn.h", "Absyn.c", "Test.c", "Parser.c", "Parser.h", "Lexer.c",
+        "Skeleton.c", "Skeleton.h", "Printer.c", "Printer.h", "Makefile " ]
+      ++ name ++ ".l " ++ name ++ ".y " ++ name ++ ".tex "]
+  $ Makefile.mkRule testName ["${OBJS}", "Test.o"]
+    [ "@echo \"Linking " ++ testName ++ "...\""
+    , "${CC} ${CCFLAGS} ${OBJS} Test.o -o " ++ testName ]
   $ Makefile.mkRule "Absyn.o" [ "Absyn.c", "Absyn.h"]
     [ "${CC} ${CCFLAGS} -c Absyn.c" ]
   $ Makefile.mkRule "Lexer.c" [ name ++ ".l" ]

--- a/source/src/BNFC/Backend/CPP/NoSTL.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL.hs
@@ -20,8 +20,8 @@
 module BNFC.Backend.CPP.NoSTL (makeCppNoStl) where
 
 import BNFC.Utils
-import BNFC.Options
 import BNFC.CF
+import BNFC.Options
 import BNFC.Backend.Base
 import BNFC.Backend.CPP.NoSTL.CFtoCPPAbs
 import BNFC.Backend.CPP.NoSTL.CFtoFlex
@@ -54,19 +54,29 @@ makeCppNoStl opts cf = do
 
 makefile :: String -> String
 makefile name =
-  (++) (unlines [ "CC = g++", "CCFLAGS = -g", "FLEX = flex", "BISON = bison", "" ])
-  $ Makefile.mkRule "all" [ "Test" ++ name ]
+  (unlines [ "CC = g++",
+             "CCFLAGS = -g -W -Wall", "",
+             "FLEX = flex",
+             "FLEX_OPTS = -P" ++ name, "",
+             "BISON = bison",
+             "BISON_OPTS = -t -p" ++ name, "",
+             "OBJS = Absyn.o Lexer.o Parser.o Printer.o", "" ] ++)
+  $ Makefile.mkRule ".PHONY" ["clean", "distclean"]
+    []
+  $ Makefile.mkRule "all" [testName]
     []
   $ Makefile.mkRule "clean" []
     -- peteg: don't nuke what we generated - move that to the "vclean" target.
-    [ "rm -f *.o " ++ name ++ ".dvi " ++ name ++ ".aux " ++ name ++ ".log " ++ name ++ ".ps Test" ++ name ]
-  $ Makefile.mkRule "distclean" []
-    [ "rm -f *.o Absyn.C Absyn.H Test.C Parser.C Parser.H Lexer.C Skeleton.C Skeleton.H Printer.C Printer.H"
-    , "rm -f " ++ name ++ ".l " ++ name ++ ".y " ++ name ++ ".tex " ++ name ++ ".dvi " ++ name ++ ".aux "
-    , "rm -f " ++ name ++ ".log " ++ name ++ ".ps Test" ++ name ++ " Makefile" ]
-  $ Makefile.mkRule ("Test" ++ name) [ "Absyn.o", "Lexer.o", "Parser.o", "Printer.o", "Test.o" ]
-    [ "@echo \"Linking Test" ++ name ++ "...\""
-    , "${CC} ${CCFLAGS} *.o -o Test" ++ name ]
+    [ "rm -f *.o " ++ testName ++ " " ++ unwords
+      [ name ++ e | e <- [".aux", ".log", ".pdf",".dvi", ".ps", ""]] ]
+  $ Makefile.mkRule "distclean" ["clean"]
+    [ "rm -f " ++ unwords
+      [ "Absyn.C", "Absyn.H", "Test.C", "Parser.C", "Parser.H", "Lexer.C",
+        "Skeleton.C", "Skeleton.H", "Printer.C", "Printer.H", "Makefile " ]
+      ++ name ++ ".l " ++ name ++ ".y " ++ name ++ ".tex "]
+  $ Makefile.mkRule (testName) [ "${OBJS}", "Test.o" ]
+    [ "@echo \"Linking " ++ testName ++ "...\""
+    , "${CC} ${CCFLAGS} ${OBJS} Test.o -o " ++ testName ]
   $ Makefile.mkRule "Absyn.o" [ "Absyn.C", "Absyn.H" ]
     [ "${CC} ${CCFLAGS} -c Absyn.C" ]
   $ Makefile.mkRule "Lexer.C" [ name ++ ".l" ]
@@ -82,7 +92,7 @@ makefile name =
   $ Makefile.mkRule "Test.o" [ "Test.C", "Parser.H", "Printer.H", "Absyn.H" ]
     [ "${CC} ${CCFLAGS} -c Test.C" ]
   ""
-
+  where testName = "Test" ++ name
 
 cpptest :: CF -> String
 cpptest cf =


### PR DESCRIPTION
This cleans things up a little on the Makefile and allows us to
make multiple binaries without linking *.o
(If your making a test program and a production program you don't
want to link the test.o to your final program.)

I also worked a little bit on making the files more similar so
it's easier to maintain them.  There is still more work to do here,
but this is a good start.  One thing to Note, I defined FLEX_OPTS and BISON_OPTS to make
 them similar but did not put the code in yet to actually use them in the files that didn't have them already.
I wanted to keep the pull manageable.