### PR TITLE
get rid of the deprecated string.set function in OCaml backend 

### DIFF
--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
@@ -64,10 +64,10 @@ header parserMod cf = [
   "        if i < 0 then l else exp (i - 1) (s.[i] :: l) in",
   "      exp (String.length s - 1) []",
   "  in let implode (l : char list) : string =",
-  "      let res = String.create (List.length l) in",
+  "      let res = Bytes.create (List.length l) in",
   "      let rec imp i = function",
   "      | [] -> res",
-  "      | c :: l -> res.[i] <- c; imp (i + 1) l in",
+  "      | c :: l -> Bytes.set res i c; imp (i + 1) l in",
   "      imp 0 l",
   "  in implode (unesc (List.tl (explode s)))",
   "",
@@ -135,7 +135,7 @@ userTokens :: CF -> [(String, String, String)]
 userTokens cf =
   let regName = map toLower . show in
   [(regName name, printRegOCaml reg, show name) | (name, reg) <- tokenPragmas cf]
-      
+
 
 
 -- | Make OCamlLex rule

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlPrinter.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlPrinter.hs
@@ -68,7 +68,7 @@ prologue _ absMod = unlines [
   "",
   "let indent (i: int) : string = ",
   "    let s = String.make (i+1) ' ' in",
-  "    String.set s 0 '\\n';",
+  "    Bytes.set s 0 '\\n';",
   "    s",
   "",
   "(* this render function is written for C-style languages, you may want to change it *)",


### PR DESCRIPTION
Replace it with bytes.set.

Refer to http://caml.inria.fr/pub/docs/manual-ocaml/libref/String.html
