### PR TITLE
Compile with GHC 7.10.2, Alex 3.14

### DIFF
--- a/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
@@ -51,6 +51,7 @@ prelude name _ shareMod shareStrings byteStrings = [
   if byteStrings  then "import qualified Data.ByteString.Char8 as BS" else "",
   "import qualified Data.Bits",
   "import Data.Word (Word8)",
+  "import Data.Char (ord)",
   "}",
   ""
   ]

--- a/source/src/LexBNF.x
+++ b/source/src/LexBNF.x
@@ -9,6 +9,7 @@ module LexBNF where
 
 import qualified Data.Bits
 import Data.Word (Word8)
+import Data.Char (ord)
 }
 
 


### PR DESCRIPTION
I added these lines to get BNFC to work with GHC 7.10.2, Alex 3.14.
I guess these additions won't work with earlier versions, so some version-checking is still required in the code.