### PR TITLE
FlexibleContexts added to doctest arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Here is how to build and run the different test suites for bnfc.
     cabal sandbox init # Cabal >= 1.18 only
     cabal install --only-dependencies --enable-tests
     cabal configure --enable-tests
+    cabal build
     cabal test
 
 Contribute
@@ -77,4 +78,3 @@ License
 -------
 
 The project is licensed under the GNU GENERAL PUBLIC LICENSE Version 2.
-

--- a/source/src/BNFC/Backend/Java/Utils.hs
+++ b/source/src/BNFC/Backend/Java/Utils.hs
@@ -3,16 +3,16 @@ import BNFC.Backend.Common.NamedVariables
 import BNFC.Utils ( mkName, NameStyle(..))
 
 javaReserved = [
-    "abstract" 	,"continue" 	,"for" 	,"new" 	,"switch"
-    ,"assert"  ,"default" 	,"goto" 	,"package" 	,"synchronized"
-    ,"boolean" 	,"do" 	,"if" 	,"private" 	,"this"
-    ,"break" 	,"double" 	,"implements" 	,"protected" 	,"throw"
-    ,"byte" 	,"else" 	,"import" 	,"public" 	,"throws"
-    ,"case" 	,"enum" 	,"instanceof" 	,"return" 	,"transient"
-    ,"catch" 	,"extends" 	,"int" 	,"short" 	,"try"
-    ,"char" 	,"final" 	,"interface" 	,"static" 	,"void"
-    ,"class" 	,"finally" 	,"long" 	,"strictfp" 	,"volatile"
-    ,"const" 	,"float" 	,"native" 	,"super" 	,"while"
+    "abstract"   ,"continue"   ,"for"   ,"new"   ,"switch"
+    ,"assert"  ,"default"   ,"goto"   ,"package"   ,"synchronized"
+    ,"boolean"   ,"do"   ,"if"   ,"private"   ,"this"
+    ,"break"   ,"double"   ,"implements"   ,"protected"   ,"throw"
+    ,"byte"   ,"else"   ,"import"   ,"public"   ,"throws"
+    ,"case"   ,"enum"   ,"instanceof"   ,"return"   ,"transient"
+    ,"catch"   ,"extends"   ,"int"   ,"short"   ,"try"
+    ,"char"   ,"final"   ,"interface"   ,"static"   ,"void"
+    ,"class"   ,"finally"   ,"long"   ,"strictfp"   ,"volatile"
+    ,"const"   ,"float"   ,"native"   ,"super"   ,"while"
     ]
 
 getRuleName z = if x `elem` ("grammar" : javaReserved) then z ++ "_" else z
@@ -21,5 +21,5 @@ getRuleName z = if x `elem` ("grammar" : javaReserved) then z ++ "_" else z
 getLabelName = mkName ["Rule"] CamelCase
 
 getLastInPackage :: String -> String
-getLastInPackage = 
+getLastInPackage =
     last . words . map (\c -> if c == '.' then ' ' else c)

--- a/source/test/doctests.hs
+++ b/source/test/doctests.hs
@@ -4,6 +4,7 @@ main = doctest
     , "-idist/build/autogen/"
     , "-idist/build/bnfc/bnfc-tmp"
     , "-XOverloadedStrings"
+    , "-XFlexibleContexts"
     , "-XRecordWildCards"
     , "src/PrintBNF.hs"
     , "src/Main.hs" ]


### PR DESCRIPTION
Hi, I had problems running the test suite with ghc-7.10.2, because the extension FlexibleContexts was missing in the arguments to doctest. 

Running the tests as described in the readme lead to a compilation error, since one has to run `cabal build` before actually running the tests. 