### PR TITLE
The precedence of reserved symbols and predefined tokens was different in Haskell and OCaml versions.

### DIFF
--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
@@ -193,15 +193,16 @@ rules cf = mkRule "token" $
     ++
     [ (mkRegexMultilineComment b e, "token lexbuf") | (b,e) <- multilineC]
     ++
+    -- reserved keywords
+    [ ( "rsyms"
+      , "let id = lexeme lexbuf in try Hashtbl.find symbol_table id with Not_found -> failwith (\"internal lexer error: reserved symbol \" ^ id ^ \" not found in hashtable\")" )
+      | not (null (cfgSymbols cf))]
+    ++
     -- user tokens
     [ (text n , tokenAction (text t)) | (n,_,t) <- userTokens cf]
     ++
     -- predefined tokens
     [ ( "l i*", tokenAction "Ident" ) ]
-    ++
-    [ ( "rsyms"
-      , "let id = lexeme lexbuf in try Hashtbl.find symbol_table id with Not_found -> failwith (\"internal lexer error: reserved symbol \" ^ id ^ \" not found in hashtable\")" )
-      | not (null (cfgSymbols cf))]
     ++
     -- integers
     [ ( "d+", "let i = lexeme lexbuf in TOK_Integer (int_of_string i)" )


### PR DESCRIPTION
-- I fixed the order in the OCaml backend.
-- The following file produces different results in Haskell and OCaml
versions.
{-
% bnfc -m -ocaml A.cf
% make
% echo ":a" | ./TestA
[Abstract syntax]

MyId (MyIdent ":a")

[Linearized tree]

:a
% bnfc -m -haskell A.cf
% make
% echo ":a" | ./TestA

Parse Successful!

[Abstract Syntax]

Keyword

[Linearized tree]

:a
-}

Keyword. Exp ::= ":a" ;
MyId.    Exp ::= MyIdent ;

token MyIdent (':' letter)