### PR TITLE
create cabal files

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -50,7 +50,8 @@ Executable bnfc
     containers,
     pretty >=1.1 && <1.2,
     filepath,
-    deepseq
+    deepseq,
+    Cabal == 1.22.*
   if  impl(ghc < 7.6.1)
     Build-depends: ghc-prim
   build-tools:         alex, happy
@@ -94,6 +95,7 @@ Executable bnfc
     BNFC.Backend.Haskell,
     BNFC.Backend.Haskell.ToCNF,
     BNFC.Backend.Haskell.RegToAlex,
+    BNFC.Backend.Haskell.CFtoCabal,
     BNFC.Backend.Haskell.CFtoTemplate,
     BNFC.Backend.Haskell.CFtoAlex3,
     BNFC.Backend.Haskell.CFtoAlex2,
@@ -191,7 +193,7 @@ Test-suite unit-tests
   Type: exitcode-stdio-1.0
   Build-Depends: base>=4 && <5, mtl, directory, array, process, filepath, pretty,
                  hspec, QuickCheck >= 2.5, HUnit,
-                 temporary, containers, deepseq
+                 temporary, containers, deepseq, Cabal == 1.22.*
   Main-is: unit-tests.hs
   HS-source-dirs: src test
   extensions: OverloadedStrings RecordWildCards FlexibleContexts

--- a/source/src/BNFC/Backend/Haskell/CFtoCabal.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoCabal.hs
@@ -1,0 +1,76 @@
+{-
+    BNF Converter: Abstract syntax Generator
+    Copyright (C) 2016  Author:  Pascal Hof
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+-}
+
+module BNFC.Backend.Haskell.CFtoCabal (cf2Cabal) where
+
+import Distribution.Simple hiding (Language)
+import Distribution.ModuleName(ModuleName,fromString)
+import Distribution.PackageDescription
+import Distribution.PackageDescription.Parse(showPackageDescription)
+
+import BNFC.Backend.Haskell.HsOpts
+import BNFC.Options hiding (Version)
+
+-- to produce a Cabal file
+cf2Cabal :: SharedOptions -> String
+cf2Cabal = showPackageDescription . buildPackageDescription
+
+buildPackageDescription :: SharedOptions -> PackageDescription
+buildPackageDescription opt = emptyPackageDescription
+  { package =
+    PackageIdentifier
+      { pkgName = PackageName (lang opt)
+      , pkgVersion = Version [0,1] []}
+  , library =
+    Just Library
+      { exposedModules = exposedMods opt
+      , reexportedModules = []
+      , requiredSignatures = []
+      , exposedSignatures = []
+      , libExposed = True
+      , libBuildInfo = emptyBuildInfo
+          { buildable    = True
+          , hsSourceDirs = ["."]
+          , targetBuildDepends = dependencies opt
+          }
+      }
+  , extraSrcFiles = [ happyFile opt, alexFile opt ]
+  , buildType = Just Simple
+  , license = AllRightsReserved
+   }
+
+dependencies :: SharedOptions -> [Dependency]
+dependencies opt =
+    [ Dependency (PackageName "base") (laterVersion $ Version [4] [])
+    , Dependency (PackageName "array") anyVersion
+    ] ++
+    [ Dependency (PackageName "mtl") anyVersion | TargetHaskellGadt == target opt ]
+
+
+-- |returns a list of all exposed modules
+exposedMods :: SharedOptions -> [ModuleName]
+exposedMods opt = map fromString $
+  [absFileM opt
+  ,errFileM opt
+  ,printerFileM opt
+  ,alexFileM opt
+  ,happyFileM opt
+  ] ++
+  [xmlFileM opt | xml opt > 0] ++
+  [composOpFileM opt | TargetHaskellGadt == target opt ]

--- a/source/src/BNFC/Backend/Haskell/HsOpts.hs
+++ b/source/src/BNFC/Backend/Haskell/HsOpts.hs
@@ -45,7 +45,7 @@ xmlFile       = mkFile withLang "XML" "hs"
 xmlFileM      = mkMod  withLang "XML"
 composOpFile  = mkFile noLang   "ComposOp" "hs"
 composOpFileM = mkMod noLang    "ComposOp"
-
+cabalFile opt = lang opt ++  ".cabal"
 
 noLang :: Options -> String -> String
 noLang _ name = name

--- a/source/src/BNFC/Backend/HaskellGADT.hs
+++ b/source/src/BNFC/Backend/HaskellGADT.hs
@@ -34,6 +34,7 @@ import BNFC.Backend.HaskellGADT.CFtoAbstractGADT
 import BNFC.Backend.HaskellGADT.CFtoTemplateGADT
 import BNFC.Backend.Haskell.CFtoPrinter
 import BNFC.Backend.Haskell.CFtoLayout
+import BNFC.Backend.Haskell.CFtoCabal
 import BNFC.Backend.XML
 import BNFC.Backend.Haskell.MkErrM
 import BNFC.Backend.Haskell.MkSharedString
@@ -71,6 +72,7 @@ makeHaskellGadt opts cf = do
     liftIO $ putStrLn "   (Tested with Happy 1.15)"
     mkfile (templateFile opts) $ cf2Template (templateFileM opts) absMod errMod cf
     mkfile (printerFile opts)  $ cf2Printer False False True prMod absMod cf
+    mkfile (cabalFile opts)    $ cf2Cabal opts
     when (hasLayout cf) $ mkfile (layoutFile opts) $ cf2Layout (alexMode opts == Alex1) (inDir opts) layMod lexMod cf
     mkfile (tFile opts)        $ Haskell.testfile opts cf
     mkfile (errFile opts) $ mkErrM errMod (ghcExtensions opts)

--- a/source/src/BNFC/Options.hs
+++ b/source/src/BNFC/Options.hs
@@ -76,6 +76,7 @@ data SharedOptions = Options
   , glr :: HappyMode
   , xml :: Int
   , ghcExtensions :: Bool
+  , cabal :: Bool
   -- C++ specific
   , linenumbers :: Bool       -- ^ Add and set line_number field for syntax classes
   -- C# specific
@@ -103,6 +104,7 @@ defaultOptions = Options
   , glr = Standard
   , xml = 0
   , ghcExtensions = False
+  , cabal = False
   , lang = error "lang not set"
   , linenumbers = False
   , visualStudio = False
@@ -122,7 +124,7 @@ globalOptions = [
 -- | Options for the target languages
 -- targetOptions :: [ OptDescr Target ]
 targetOptions :: [ OptDescr (SharedOptions -> SharedOptions)]
-targetOptions = 
+targetOptions =
   [ Option "" ["java"]          (NoArg (\o -> o {target = TargetJava}))
     "Output Java code [default: for use with JLex and CUP]"
   , Option "" ["haskell"]       (NoArg (\o -> o {target = TargetHaskell}))
@@ -206,6 +208,9 @@ specificOptions =
   , ( Option []    ["ghc"] (NoArg (\o -> o {ghcExtensions = True}))
           "Use ghc-specific language extensions"
     , [TargetHaskell, TargetHaskellGadt, TargetProfile] )
+  , ( Option []    ["cabal"] (NoArg (\o -> o {cabal = True}))
+          "Also generate cabal file"
+    , [TargetHaskell,TargetHaskellGadt] )
   , ( Option []    ["functor"] (NoArg (\o -> o {functor = True}))
           "Make the AST a functor and use it to store the position of the nodes"
     , [TargetHaskell] )
@@ -301,4 +306,3 @@ translateOldOptions = concatMap translateOne
         translateOne "-vs"            = return "--vs"
         translateOne "-wcf"           = return "--wcf"
         translateOne other            = return other
-

--- a/source/test/BNFC/Backend/HaskellSpec.hs
+++ b/source/test/BNFC/Backend/HaskellSpec.hs
@@ -56,3 +56,9 @@ spec = do
       calc <- getCalc
       let options = calcOptions { make = Just "MyMakefile" }
       makeHaskell options calc `shouldGenerate` "MyMakefile"
+
+  context "with option --cabal and the Calc grammar" $ do
+    it "generates a cabal file" $ do
+      calc <- getCalc
+      let options = calcOptions { cabal = True }
+      makeHaskell options calc `shouldGenerate` "Calc.cabal"      

--- a/testing/Main.hs
+++ b/testing/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Framework (htfMain)
 
+import HaskellCabalTests
 import HaskellCnfTests
 import ParameterizedTests
 import PygmentsTests
@@ -12,4 +13,6 @@ main = htfMain [ ParameterizedTests.all
                , RegressionTests.all
                , PygmentsTests.all
                , HaskellCnfTests.all
-               , OutputParser.tests ]
+               , OutputParser.tests
+               , HaskellCabalTests.all
+               ]

--- a/testing/src/HaskellCabalTests.hs
+++ b/testing/src/HaskellCabalTests.hs
@@ -1,0 +1,44 @@
+module HaskellCabalTests (all) where
+
+import Shelly
+import Prelude hiding (all,unlines)
+import Data.Text(Text,unlines,unpack)
+import TestUtils(Test,makeShellyTest,makeTestSuite,assertFileExists)
+
+all = makeTestSuite "Haskell/Cabal"
+  [ mkTest target desc ps
+  | (desc,ps) <- params
+  , target <- ["--haskell","--haskell-gadt"]
+  ]
+
+-- |a list of test description and the respective arguments to bnfc
+params :: [(String,[Text])]
+params =
+  [("Cabal only",[])
+  ,("Ghc",["--ghc"])
+  ,("Functor",["--functor"])
+  ,("Xml",["--xml"])
+  ,("Xmlt",["--xmlt"])
+  ,("Qualified",["-d"])
+  ,("Namespace",["-p","Foobar"])
+  ,("Qualified namespace",["-p","Foobar","-d"])
+  ]
+
+-- |building the Shelly Test
+mkTest :: Text -> String -> [Text] -> Test
+mkTest target desc bnfcParams =
+  makeShellyTest description $ withTmpDir $ \tmp -> do
+    cd tmp
+    writefile "Test.cf" $ unlines
+      [ "Start. S ::= S \"a\" ;"
+      , "End.   S ::= ;" ]
+    run_ "bnfc" args
+    assertFileExists "Test.cabal"
+    cmd "cabal" "configure"
+    cmd "cabal" "build"
+    where
+      args :: [Text]
+      args = target:"--cabal":bnfcParams ++ ["Test.cf"]
+
+      description :: String
+      description = desc++",Target "++drop 2 (unpack target)


### PR DESCRIPTION
This pull request allows bnfc to create cabal files in order to build/install the generated modules. 

(I will start working on a cabal hook, which lets you use bnfc as a preprocessor to cabal.)