### PR TITLE
Generating prefixes in CPP (issue 172)

### DIFF
--- a/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
@@ -109,9 +109,9 @@ header inPackage name cf = unlines
     , "}"
     , "void " ++ ns ++ "yyerror(const char *str)"
     , "{"
-    , "  extern char *yytext;"
+    , "  extern char *"++ns++"yytext;"
     , "  fprintf(stderr,\"error: line %d: %s at %s\\n\", "
-    , "    yy_mylinenumber, str, yytext);"
+    , "    "++ns++"yy_mylinenumber, str, "++ns++"yytext);"
     , "}"
     , ""
     , definedRules cf
@@ -393,5 +393,3 @@ typeName "Char" = "_CHAR_"
 typeName "Integer" = "_INTEGER_"
 typeName "Double" = "_DOUBLE_"
 typeName x = x
-
-

--- a/testing/src/RegressionTests.hs
+++ b/testing/src/RegressionTests.hs
@@ -17,7 +17,9 @@ all = makeTestSuite "Regression tests"
     , issue60
     , issue108, issue110, issue111, issue114, issue113
     , issue127, issue128
-    , issue151 ]
+    , issue151
+    , issue172
+    ]
 
 issue30 :: Test
 issue30 = makeShellyTest "#30 With -d option XML module is not generated inside the directorty" $
@@ -145,3 +147,14 @@ issue151 = makeShellyTest "#151 Shouldn't print all categories in error message"
                   [ "no production for Baz, appearing in rule"
                   , "    Foo. Bar ::= Baz", "" ]
           assertEqual expectedErr err
+
+-- |Issue #172
+issue172 :: Test
+issue172 = makeShellyTest "#172 Prefixes not generated correctly in CPP" $
+    withTmpDir $ \tmp -> do
+        cd tmp
+        writefile "Test.cf" $ T.unlines
+            [ "Start. S ::= S \"a\" ;"
+            , "End.   S ::= ;" ]
+        cmd "bnfc" "-m" "--cpp" "-p" "Haskell" "Test.cf"
+        cmd "make"


### PR DESCRIPTION
These changes should solve issue #172 and thus make the cpp-backend generate code with prefixed names correctly.