### PR TITLE
[C] Emit correct function prototypes

### DIFF
--- a/source/src/BNFC/Backend/C/CFtoCAbs.hs
+++ b/source/src/BNFC/Backend/C/CFtoCAbs.hs
@@ -138,7 +138,7 @@ prRuleH c (fun, cats) =
       show c ++ " make_" ++ fun ++ "(" ++ (prParamsH 0 (getVars cats)) ++ ");\n"
    where
      prParamsH :: Int -> [(String, a)] -> String
-     prParamsH _ [] = ""
+     prParamsH _ [] = "void"
      prParamsH n ((t,_):[]) = t ++ " p" ++ (show n)
      prParamsH n ((t,_):vs) = (t ++ " p" ++ (show n) ++ ", ") ++ (prParamsH (n+1) vs)
 


### PR DESCRIPTION
This affects the generated file `Absyn.h`.

Example before:
```
    Full_combinator_id make_AbsentFCID();
```
Example after:
```
    Full_combinator_id make_AbsentFCID(void);
```

This change is required as `make_AbsentFCID()` in C actually
means "takes an arbitrary amount of arguments", which is not
the desired semantics.

`make test` passes all suites.  Someone should probably write a regression test for this, so this bug isn't introduced again.