### PR TITLE
ghc-7.6.3 in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: haskell
+ghc:
+  - 7.6.3
 script:
     - cabal install
     - cabal configure --enable-tests && cabal build && cabal test


### PR DESCRIPTION
In the time between these two commits the travis build started to fail without changes being made to the configuration: [working, 2016-11-19](https://github.com/BNFC/bnfc/pull/195/commits) [failing, 2016-12-13](https://github.com/BNFC/bnfc/pull/199/commits)

The problem is that the travis default config changed from ghc-7.6.3 to ghc-7.8.4, which causes the bnfc ci to fail. This pull request sets the ghc version in travis back to ghc-7.6.3.