### PR TITLE
cabal file: bumped version from 2.8 to 2.8.2

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -1,5 +1,5 @@
 Name: BNFC
-Version: 2.8
+Version: 2.8.2
 cabal-version: >= 1.8
 build-type: Simple
 category: Development


### PR DESCRIPTION
Currently, the development version is behind the released
version (2.8.1), which is strange.

Upon release, the version can be corrected again.