### PR TITLE
Fix rule for token position example

### DIFF
--- a/document/tutorial/bnfc-tutorial.txt
+++ b/document/tutorial/bnfc-tutorial.txt
@@ -1133,7 +1133,7 @@ See LBNF report for more information.
 
 The position of a token can be passed to the syntax tree:
 ```
-  position token CIdent (letter | (letter | digit | '_')*) ;
+  position token CIdent (letter (letter | digit | '_')*) ;
 ```
 See LBNF report for more information.
 


### PR DESCRIPTION
The sample rule for CIdent has a "|" in it by mistake. The error makes CIdent accept empty strings which causes problems and raises the following warning:

Warning : 
  The following tokens accept the empty string: 
    CIdent
  This is error-prone and will not be supported in the future.