### PR TITLE
docs - add missing comment syntax information

### DIFF
--- a/docs/lbnf.rst
+++ b/docs/lbnf.rst
@@ -963,8 +963,8 @@ The symbols used in BNF are the following::
 Comments
 --------
 
-| Single-line comments begin with .
-| Multiple-line comments are enclosed with and .
+| Single-line comments begin with `--`.
+| Multiple-line comments are enclosed with `{-` and `-}`.
 
 The syntactic structure of BNF
 ==============================


### PR DESCRIPTION
Was looking for this information, took me a while to find it. A friend pointed out these docs with the crucial parts missing.