### PR TITLE
Handle pretty and base <> collision

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -58,7 +58,7 @@ Executable bnfc
     deepseq
   build-tools:         alex, happy
   Main-is: Main.hs
-  HS-source-dirs: src/
+  HS-source-dirs: compat src
   ghc-options:     -W
   extensions:
     FlexibleContexts
@@ -77,6 +77,7 @@ Executable bnfc
     PrintBNF,
     ErrM,
     -- BNFC core
+    Prelude',
     BNFC.Utils,
     BNFC.CF,
     BNFC.ToCNFCore,
@@ -202,7 +203,7 @@ Test-suite unit-tests
                  hspec, QuickCheck >= 2.5, HUnit,
                  temporary, containers, deepseq
   Main-is: unit-tests.hs
-  HS-source-dirs: src test
+  HS-source-dirs: compat src test
   extensions:
     FlexibleContexts
     LambdaCase

--- a/source/compat/Prelude'.hs
+++ b/source/compat/Prelude'.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP #-}
+
+-- See #227 for what's going on here.
+
+module Prelude'
+(
+  module P
+)
+where
+
+#if __GLASGOW_HASKELL__ >= 803
+import Prelude as P hiding ((<>))
+#else
+import Prelude as P
+#endif

--- a/source/src/BNFC/Backend/C.hs
+++ b/source/src/BNFC/Backend/C.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C Main file
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -17,6 +19,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -}
 module BNFC.Backend.C (makeC) where
+
+import Prelude'
 
 import BNFC.Utils
 import BNFC.CF

--- a/source/src/BNFC/Backend/C/CFtoCAbs.hs
+++ b/source/src/BNFC/Backend/C/CFtoCAbs.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C Abstract syntax
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -40,6 +42,7 @@
 
 module BNFC.Backend.C.CFtoCAbs (cf2CAbs) where
 
+import Prelude'
 
 import BNFC.CF
 import BNFC.PrettyPrint

--- a/source/src/BNFC/Backend/C/CFtoCPrinter.hs
+++ b/source/src/BNFC/Backend/C/CFtoCPrinter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C Pretty Printer printer
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -40,6 +42,8 @@
 -}
 
 module BNFC.Backend.C.CFtoCPrinter (cf2CPrinter) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils ((+++))

--- a/source/src/BNFC/Backend/C/CFtoCSkel.hs
+++ b/source/src/BNFC/Backend/C/CFtoCSkel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C Skeleton generator
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -38,6 +40,8 @@
 -}
 
 module BNFC.Backend.C.CFtoCSkel (cf2CSkel) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils                       ( (+++) )

--- a/source/src/BNFC/Backend/C/CFtoFlexC.hs
+++ b/source/src/BNFC/Backend/C/CFtoFlexC.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C flex generator
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -36,6 +38,8 @@
    **************************************************************
 -}
 module BNFC.Backend.C.CFtoFlexC (cf2flex, lexComments, cMacros) where
+
+import Prelude'
 
 import Data.Maybe (fromMaybe)
 

--- a/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
 {-
     BNF Converter: C++ abstract syntax generator
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -40,6 +40,8 @@
 -}
 
 module BNFC.Backend.CPP.NoSTL.CFtoCPPAbs (cf2CPPAbs) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils((+++),(++++))

--- a/source/src/BNFC/Backend/CPP/NoSTL/CFtoCVisitSkel.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL/CFtoCVisitSkel.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C++ Skeleton generation
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -38,6 +40,8 @@
 -}
 
 module BNFC.Backend.CPP.NoSTL.CFtoCVisitSkel (cf2CVisitSkel) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils ((+++))

--- a/source/src/BNFC/Backend/CPP/PrettyPrinter.hs
+++ b/source/src/BNFC/Backend/CPP/PrettyPrinter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
    **************************************************************
     BNF Converter Module
@@ -21,6 +23,8 @@
 -}
 
 module BNFC.Backend.CPP.PrettyPrinter (cf2CPPPrinter, prRender) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils ((+++))

--- a/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: C++ Bison generator
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -43,6 +45,8 @@
 
 
 module BNFC.Backend.CPP.STL.CFtoBisonSTL (cf2Bison, union) where
+
+import Prelude'
 
 import Data.Char (toLower,isUpper)
 import Data.List (nub, intercalate)

--- a/source/src/BNFC/Backend/Common.hs
+++ b/source/src/BNFC/Backend/Common.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 -- | Functions common to different backends.
 
 module BNFC.Backend.Common (renderListSepByPrecedence) where
+
+import Prelude'
 
 import BNFC.PrettyPrint
 

--- a/source/src/BNFC/Backend/Common/Makefile.hs
+++ b/source/src/BNFC/Backend/Common/Makefile.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module BNFC.Backend.Common.Makefile where
+
+import Prelude'
 
 import BNFC.Options (SharedOptions(..))
 import BNFC.Backend.Base (mkfile, Backend)

--- a/source/src/BNFC/Backend/Common/NamedVariables.hs
+++ b/source/src/BNFC/Backend/Common/NamedVariables.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoImplicitPrelude #-}
 
 {-
     BNF Converter: Named instance variables
@@ -66,6 +67,8 @@ This is what this module does.
 -}
 
 module BNFC.Backend.Common.NamedVariables where
+
+import Prelude'
 
 import BNFC.CF
 import Data.Char (toLower)

--- a/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Abstract syntax Generator
     Copyright (C) 2004  Author:  Markus Forberg
@@ -18,6 +20,8 @@
 -}
 
 module BNFC.Backend.Haskell.CFtoAbstract (cf2Abstract) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Utils((+++))

--- a/source/src/BNFC/Backend/Haskell/CFtoPrinter.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoPrinter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Pretty-printer generator
     Copyright (C) 2004  Author:  Aarne Ranta
@@ -18,6 +20,8 @@
 -}
 
 module BNFC.Backend.Haskell.CFtoPrinter (cf2Printer, compareRules) where
+
+import Prelude'
 
 import BNFC.Backend.Haskell.Utils (hsReservedWords)
 import BNFC.CF

--- a/source/src/BNFC/Backend/Haskell/CFtoTemplate.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoTemplate.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Template Generator
     Copyright (C) 2004  Author:  Markus Forberg
@@ -19,6 +21,8 @@
 
 
 module BNFC.Backend.Haskell.CFtoTemplate (cf2Template) where
+
+import Prelude'
 
 import BNFC.Backend.Haskell.Utils (catvars)
 import BNFC.CF

--- a/source/src/BNFC/Backend/Haskell/MkErrM.hs
+++ b/source/src/BNFC/Backend/Haskell/MkErrM.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Haskell error monad
     Copyright (C) 2004-2007  Author:  Markus Forberg, Peter Gammie,
@@ -18,6 +20,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -}
 module BNFC.Backend.Haskell.MkErrM where
+
+import Prelude'
 
 import BNFC.PrettyPrint
 

--- a/source/src/BNFC/Backend/Haskell/Utils.hs
+++ b/source/src/BNFC/Backend/Haskell/Utils.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module BNFC.Backend.Haskell.Utils
   ( parserName
   , hsReservedWords
   , catToType
   , catvars
   ) where
+
+import Prelude'
 
 import Text.PrettyPrint
 import BNFC.CF (Cat(..), identCat, normCat)

--- a/source/src/BNFC/Backend/Java.hs
+++ b/source/src/BNFC/Backend/Java.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java Top File
     Copyright (C) 2004  Author:  Markus Forsberg, Peter Gammie,
@@ -34,6 +36,8 @@
 -------------------------------------------------------------------
 
 module BNFC.Backend.Java ( makeJava ) where
+
+import Prelude'
 
 import System.FilePath (pathSeparator, isPathSeparator)
 import Data.List ( intersperse )

--- a/source/src/BNFC/Backend/Java/CFtoAntlr4Lexer.hs
+++ b/source/src/BNFC/Backend/Java/CFtoAntlr4Lexer.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java Antlr4 Lexer generator
     Copyright (C) 2015  Author:  Gabriele Paganelli
@@ -37,6 +39,8 @@
 -}
 
 module BNFC.Backend.Java.CFtoAntlr4Lexer ( cf2AntlrLex ) where
+
+import Prelude'
 
 import Text.PrettyPrint
 import BNFC.CF

--- a/source/src/BNFC/Backend/Java/CFtoComposVisitor.hs
+++ b/source/src/BNFC/Backend/Java/CFtoComposVisitor.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java 1.5 Compositional Vistor generator
     Copyright (C) 2006 Bjorn Bringert
@@ -19,6 +21,8 @@
 -}
 
 module BNFC.Backend.Java.CFtoComposVisitor (cf2ComposVisitor) where
+
+import Prelude'
 
 import Data.List
 import Data.Either (lefts)

--- a/source/src/BNFC/Backend/Java/CFtoFoldVisitor.hs
+++ b/source/src/BNFC/Backend/Java/CFtoFoldVisitor.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java 1.5 Fold Vistor generator
     Copyright (C) 2006 Bjorn Bringert
@@ -19,6 +21,8 @@
 -}
 
 module BNFC.Backend.Java.CFtoFoldVisitor (cf2FoldVisitor) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Backend.Java.CFtoJavaAbs15 (typename)

--- a/source/src/BNFC/Backend/Java/CFtoJLex15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJLex15.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java JLex generator
     Copyright (C) 2004  Author:  Michael Pellauer
@@ -38,6 +40,8 @@
 -}
 
 module BNFC.Backend.Java.CFtoJLex15 ( cf2jlex ) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Backend.Common.NamedVariables

--- a/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
 {-
     BNF Converter: Java 1.5 Abstract Syntax
     Copyright (C) 2004  Author:  Michael Pellauer, Bjorn Bringert
@@ -45,6 +45,8 @@
 -}
 
 module BNFC.Backend.Java.CFtoJavaAbs15 (cf2JavaAbs, typename, cat2JavaType) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Options (RecordPositions(..))

--- a/source/src/BNFC/Backend/Java/CFtoJavaPrinter15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJavaPrinter15.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java Pretty Printer generator
     Copyright (C) 2004  Author:  Michael Pellauer, Bjorn Bringert
@@ -45,6 +47,8 @@
    **************************************************************
 -}
 module BNFC.Backend.Java.CFtoJavaPrinter15 ( cf2JavaPrinter ) where
+
+import Prelude'
 
 import BNFC.Backend.Java.CFtoJavaAbs15
 

--- a/source/src/BNFC/Backend/Java/CFtoVisitSkel15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoVisitSkel15.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Java Vistor skeleton generator
     Copyright (C) 2004  Author:  Michael Pellauer, Bjorn Bringert
@@ -39,6 +41,8 @@
    **************************************************************
 -}
 module BNFC.Backend.Java.CFtoVisitSkel15 (cf2VisitSkel) where
+
+import Prelude'
 
 import BNFC.CF
 import BNFC.Backend.Java.CFtoJavaAbs15 (typename)

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: ocamllex Generator
     Copyright (C) 2005  Author:  Kristofer Johannisson
@@ -21,6 +23,8 @@
 -- based on BNFC Haskell backend
 
 module BNFC.Backend.OCaml.CFtoOCamlLex (cf2ocamllex) where
+
+import Prelude'
 
 import Control.Arrow ((&&&))
 import Data.List

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlPrinter.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlPrinter.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Pretty-printer generator
     Copyright (C) 2005  Author:  Kristofer Johannisson
@@ -20,6 +22,8 @@
 -- based on BNFC Haskell backend
 
 module BNFC.Backend.OCaml.CFtoOCamlPrinter (cf2Printer) where
+
+import Prelude'
 
 import Data.Char(toLower)
 import Data.List (intersperse, sortBy)

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlTest.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlTest.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {-
     BNF Converter: Generate main/test module for OCaml
     Copyright (C) 2005  Author:  Kristofer Johannisson
@@ -18,6 +20,8 @@
 -}
 
 module BNFC.Backend.OCaml.CFtoOCamlTest where
+
+import Prelude'
 
 import Text.PrettyPrint
 

--- a/source/src/BNFC/Backend/Pygments.hs
+++ b/source/src/BNFC/Backend/Pygments.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 {- Generates a Pygments lexer from a BNF grammar.
  -
  - Resources:
@@ -7,6 +9,7 @@
  - -}
 module BNFC.Backend.Pygments where
 
+import Prelude'
 
 import AbsBNF (Reg(..))
 import BNFC.Backend.Base (mkfile, Backend)

--- a/source/src/BNFC/Lexing.hs
+++ b/source/src/BNFC/Lexing.hs
@@ -1,5 +1,9 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module BNFC.Lexing
     ( mkLexer, LexType(..) ) where
+
+import Prelude'
 
 import Control.Arrow ((&&&))
 import Data.List (inits)

--- a/source/src/BNFC/PrettyPrint.hs
+++ b/source/src/BNFC/PrettyPrint.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 -- Extends Text.PrettyPrint
 module BNFC.PrettyPrint
   ( module Text.PrettyPrint
@@ -6,6 +8,8 @@ module BNFC.PrettyPrint
   , vsep
   , (<=>)
   ) where
+
+import Prelude'
 
 import Text.PrettyPrint
 

--- a/source/src/README.md
+++ b/source/src/README.md
@@ -1,6 +1,11 @@
 Comments on the source code
 ===========================
 
+2018-03-27
+
+  If you want to use `<>` from pretty you must include `Prelude'` instead of
+  `Prelude`. See #227. This is hopefully a temporary hack.
+
 2017-11-21
 
   The LBNF grammar is currently not boot-strapped,

--- a/source/test/doctests.hs
+++ b/source/test/doctests.hs
@@ -1,7 +1,8 @@
 import Test.DocTest
 
 main = doctest
-    [ "-isrc"
+    [ "-icompat"
+    , "-isrc"
     , "-idist/build/autogen/"
     , "-idist/build/bnfc/bnfc-tmp"
     , "-XLambdaCase"


### PR DESCRIPTION
Because `<>` was added to Prelude in base 4.11.0.0 one gets the following error when trying to build BNFC with e.g. GHC 8.4.1:

```
[10 of 97] Compiling BNFC.PrettyPrint ( src/BNFC/PrettyPrint.hs, dist/build/bnfc/bnfc-tmp/BNFC/PrettyPrint.o )

src/BNFC/PrettyPrint.hs:16:13: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at src/BNFC/PrettyPrint.hs:2:8-23
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.<>’,
                             imported from ‘Text.PrettyPrint’ at src/BNFC/PrettyPrint.hs:10:1-23
                             (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
   |
16 | a <.> b = a <> "." <> b
   |             ^^

src/BNFC/PrettyPrint.hs:16:20: error:
    Ambiguous occurrence ‘<>’
    It could refer to either ‘Prelude.<>’,
                             imported from ‘Prelude’ at src/BNFC/PrettyPrint.hs:2:8-23
                             (and originally defined in ‘GHC.Base’)
                          or ‘Text.PrettyPrint.<>’,
                             imported from ‘Text.PrettyPrint’ at src/BNFC/PrettyPrint.hs:10:1-23
                             (and originally defined in ‘Text.PrettyPrint.HughesPJ’)
   |
16 | a <.> b = a <> "." <> b
   |                    ^^
```

I'm not sure about the proper way of fixing this, but this PR at least builds on GHC 8.4.1. See also haskell/pretty#30.