### PR TITLE
Update lbnf.rst

### DIFF
--- a/docs/lbnf.rst
+++ b/docs/lbnf.rst
@@ -26,7 +26,7 @@ addition expressions with “1”:
 
 ::
 
-      EPlus. Exp ::= Exp "+" Num ;
+      EPlus. Exp ::= Exp "+" Exp ;
       ENum.  Exp ::= Num ;
       NOne.  Num ::= "1" ;
 


### PR DESCRIPTION
Adjust `Exp` definition.

Without this change, the ADTs produced will be:

```haskell
data Exp = EPlus Exp Num | ENum Num
data Num = NOne
```

instead of
```haskell
data Exp = EPlus Exp Exp | ENum Num
data Num = NOne
```