### PR TITLE
[ CPP ] Throw runtime exception on parsing error

### DIFF
--- a/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoBisonSTL.hs
@@ -106,6 +106,7 @@ header inPackage name cf = unlines
     , "#include <stdio.h>"
     , "#include <string.h>"
     , "#include <algorithm>"
+    , "#include \"ParserError.H\""
     , "#include \"Absyn.H\""
     , ""
     , "#define YYMAXDEPTH 10000000"  -- default maximum stack size is 10000, but right-recursion needs O(n) stack
@@ -124,8 +125,7 @@ header inPackage name cf = unlines
     , "void " ++ ns ++ "yyerror(const char *str)"
     , "{"
     , "  extern char *"++ns++"yytext;"
-    , "  fprintf(stderr,\"error: line %d: %s at %s\\n\", "
-    , "    "++ns++"yy_mylinenumber, str, "++ns++"yytext);"
+    , "  throw "++ns++"::parse_error("++ ns ++ "yy_mylinenumber,str);"
     , "}"
     , ""
     , nsStart inPackage


### PR DESCRIPTION
When BNFC generated code embedded into another project it's more convenient to get parsing errors as C++ exceptions rather than just via standard output.

I've added `parse_error` class to the `Absyn.H`
```
class parse_error : public std::runtime_error {
  public:
  parse_error(int line, std::string str) : std::runtime_error(str) , m_line(line) {}
  int getLine() { return m_line; }
  private:
  int m_line;
  };
```