### PR TITLE
Fix nullptr not declared error in CPP backend

### DIFF
--- a/source/src/BNFC/Backend/CPP/STL.hs
+++ b/source/src/BNFC/Backend/CPP/STL.hs
@@ -140,7 +140,7 @@ cpptest inPackage cf =
     "    }",
     "  } else input = stdin;",
     "  /* The default entry point is used. For other options see Parser.H */",
-    "  " ++ scope ++ dat ++ " *parse_tree = nullptr;",
+    "  " ++ scope ++ dat ++ " *parse_tree = NULL;",
     "  try { ",
     "  parse_tree = " ++ scope ++ "p" ++ def ++ "(input);",
     "  } catch( " ++ scope ++ "parse_error &e) {",


### PR DESCRIPTION
`nullptr` becomes a keyword since C++11. Let's use `NULL` instead.

```
g++ -g --ansi -W -Wall -Wno-unused-parameter -Wno-unused-function -Wno-unneeded-internal-declaration -c Test.C
Test.C:50:21: warning: identifier ‘nullptr’ is a keyword in C++11 [-Wc++11-compat]
   50 |   Exp *parse_tree = nullptr;
      |                     ^~~~~~~
Test.C: In function ‘int main(int, char**)’:
Test.C:50:21: error: ‘nullptr’ was not declared in this scope
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unneeded-internal-declaration’ may have been intended to silence earlier diagnostics
make: *** [Makefile:48: Test.o] Error 1
```