### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -65,7 +65,6 @@ Executable bnfc
   default-language: Haskell2010
   Build-Depends:
     base>=4.8 && <5,
-    semigroups,
     mtl >= 2.2.1,
     directory,
     array,
@@ -75,6 +74,8 @@ Executable bnfc
     filepath,
     deepseq,
     time
+  if impl(ghc < 8.0)
+    Build-Depends: semigroups
   build-tools:         alex, happy
   Main-is: Main.hs
   HS-source-dirs: src
@@ -202,7 +203,6 @@ Test-suite unit-tests
   Build-Depends:
     -- base-4.9 would be needed for Show1 needed for Show WriterT
     base>=4.8 && <5,
-    semigroups,
     mtl >= 2.2.1,
     directory,
     array,
@@ -216,6 +216,8 @@ Test-suite unit-tests
     containers,
     deepseq,
     time
+  if impl(ghc < 8.0)
+    Build-Depends: semigroups
   Main-is: unit-tests.hs
   HS-source-dirs: src test
   ghc-options:     -W


### PR DESCRIPTION
It's not needed on newer GHC.