### PR TITLE
Add newline to Parse error message in C++ backend

### DIFF
--- a/source/src/BNFC/Backend/CPP/STL.hs
+++ b/source/src/BNFC/Backend/CPP/STL.hs
@@ -144,7 +144,7 @@ cpptest inPackage cf =
     "  try { ",
     "  parse_tree = " ++ scope ++ "p" ++ def ++ "(input);",
     "  } catch( " ++ scope ++ "parse_error &e) {",
-    "     std::cerr << \"Parse error on line \" << e.getLine(); ",
+    "     std::cerr << \"Parse error on line \" << e.getLine() << \"\\n\"; ",
     "  }",
     "  if (parse_tree)",
     "  {",


### PR DESCRIPTION
There was a missing newline on the error message where the parsing failed