### PR TITLE
C backend: Parser.h: #include <stdio.h>

### DIFF
--- a/source/src/BNFC/Backend/C.hs
+++ b/source/src/BNFC/Backend/C.hs
@@ -220,6 +220,7 @@ mkHeaderFile _ cf _env = unlines $ concat
   [ [ "#ifndef PARSER_HEADER_FILE"
     , "#define PARSER_HEADER_FILE"
     , ""
+    , "#include <stdio.h>"
     , "#include \"Absyn.h\""
     , ""
     ]

--- a/source/src/BNFC/Backend/CPP/STL.hs
+++ b/source/src/BNFC/Backend/CPP/STL.hs
@@ -170,6 +170,7 @@ mkHeaderFile inPackage _cf _cats eps _env = unlines $ concat
     , ""
     , "#include<vector>"
     , "#include<string>"
+    , "#include<cstdio>"
     , "#include \"Absyn.H\""
     , ""
     , nsStart inPackage


### PR DESCRIPTION
Parser.h uses FILE*, however doesn't include stdio.h, even transitively.
This is an issue if using the C backend from Zig, where usage of C FILE
api is not needed.

Fixes #381.