### PR TITLE
STL C++ backend: fix --line-numbers. There was a missing field

### DIFF
--- a/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
@@ -117,7 +117,7 @@ prAbs rp c = unlines [
   "{",
   "public:",
   "  virtual " ++ c ++ " *clone() const = 0;",
-  if rp == RecordPositions then "  int line_number;" else "",
+  if rp == RecordPositions then "  int line_number, char_number;" else "",
   "};"
   ]
 


### PR DESCRIPTION
char_number, which prevented examples from compiling.