### PR TITLE
Make `closingToken` function pattern matching exhaustive

### DIFF
--- a/source/src/BNFC/Backend/Haskell/CFtoLayout.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoLayout.hs
@@ -206,6 +206,7 @@ cf2Layout layName lexName cf = unlines $ concat
     , "  closingToken :: Position -> Block -> Token"
     , "  closingToken pos = sToken pos . \\case"
     , "    Implicit (LayoutDelimiters _ _ (Just sy)) _ _ -> sy"
+    , "    _ -> error \"Trying to close a top level block.\""
     , ""
     , "type Position = Posn"
     , "type Line     = Int"


### PR DESCRIPTION
The `closingToken` function cases in the layout solver were not exhaustive