### PR TITLE
[ java ] replace deprecated `new Double` by `Double.valueOf` 

### DIFF
--- a/source/src/BNFC/Backend/Java/CFtoJLex15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJLex15.hs
@@ -159,9 +159,9 @@ restOfJLex jflex rp cf = vcat
     , ifC catString strStates
     , ifC catChar chStates
     , ifC catDouble
-        "<YYINITIAL>{DIGIT}+\".\"{DIGIT}+(\"e\"(\\-)?{DIGIT}+)? { return cf.newSymbol(\"\", sym._DOUBLE_, left_loc(), right_loc(), new Double(yytext())); }"
+        "<YYINITIAL>{DIGIT}+\".\"{DIGIT}+(\"e\"(\\-)?{DIGIT}+)? { return cf.newSymbol(\"\", sym._DOUBLE_, left_loc(), right_loc(), Double.valueOf(yytext())); }"
     , ifC catInteger
-        "<YYINITIAL>{DIGIT}+ { return cf.newSymbol(\"\", sym._INTEGER_, left_loc(), right_loc(), new Integer(yytext())); }"
+        "<YYINITIAL>{DIGIT}+ { return cf.newSymbol(\"\", sym._INTEGER_, left_loc(), right_loc(), Integer.valueOf(yytext())); }"
     , ifC catIdent
         "<YYINITIAL>{LETTER}{IDENT}* { return cf.newSymbol(\"\", sym._IDENT_, left_loc(), right_loc(), yytext().intern()); }"
     , "<YYINITIAL>[ \\t\\r\\n\\f] { /* ignore white space. */ }"

--- a/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
@@ -118,10 +118,10 @@ definedRules defs packageAbsyn cf = map rule defs
              | isUpper (head x) -> callQ x es
              | otherwise        -> call (sanitize x) es
             -- -- | x `elem` args    -> call x es
-           LitInt n             -> "new Integer(" ++ show n ++ ")"
-           LitDouble x          -> "new Double(" ++ show x ++ ")"
-           LitChar c            -> "new Character(" ++ show c ++ ")"
-           LitString s          -> "new String(" ++ show s ++ ")"
+           LitInt n             -> "Integer.valueOf(" ++ show n ++ ")"
+           LitDouble x          -> "Double.valueOf(" ++ show x ++ ")"
+           LitChar c            -> "Character.valueOf(" ++ show c ++ ")"
+           LitString s          -> "String.valueOf(" ++ show s ++ ")"
          where
          call x es = x ++ "(" ++ intercalate ", " (map (javaExp args) es) ++ ")"
          callQ     = call . qualify


### PR DESCRIPTION
`new Double(...)` is deprecated in favor of `Double.valueOf(...)`.
Same for `Integer` etc.