### PR TITLE
Bump CI from GHC 9.0.1 to 9.0.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211116
+# version: 0.14
 #
-# REGENDATA ("0.13.20211116",["github","cabal.project"])
+# REGENDATA ("0.14",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -33,10 +33,10 @@ jobs:
             compilerVersion: 9.2.1
             setup-method: ghcup
             allow-failure: true
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -121,7 +121,7 @@ jobs:
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           if [ $((HCNUMVER > 90201)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
@@ -248,7 +248,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
         run: |
-          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct ; fi
+          $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
         run: |
           cd ${PKGDIR_BNFC} || false

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         # Note: check release logic below when changing the matrix!
-        ghc: [9.0.1, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
+        ghc: [9.0.2, 8.10.7, 8.8.4, 8.6.5, 8.4.4, 8.2.2, 8.0.2]
         os: [ubuntu-latest]
         include:
           - os: macOS-latest
-            ghc: 9.0.1
+            ghc: 9.0.2
           - os: windows-latest
-            ghc: 9.0.1
+            ghc: 9.0.2
 
 
     # Needed for Windows to make piping (... >> ...) and evaluation ( $(...) ) work.
@@ -112,7 +112,7 @@ jobs:
         # Conditional to ensure this deployment is only run once per action.
         if: >-
           startsWith(github.ref, 'refs/tags/v')
-          && matrix.ghc == '9.0.1'
+          && matrix.ghc == '9.0.2'
         run: |
           export DIST_TGZ=$(cabal sdist source | tail -1)
           echo "DIST_TGZ=${DIST_TGZ}" >> ${GITHUB_ENV}
@@ -120,7 +120,7 @@ jobs:
       - name: Source tarball release.
         if: >-
           startsWith(github.ref, 'refs/tags/v')
-          && matrix.ghc == '9.0.1'
+          && matrix.ghc == '9.0.2'
         uses: softprops/action-gh-release@v1
         with:
           draft: true

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -31,12 +31,8 @@ no-tests-no-benchmarks: >= 9.0.1
 -- end
 ---------------------------------------------------------------------------
 
--- on Linux we can use ghcup to setup (some) of jobs
--- hvr-ppa latest are 9.0.1 and 8.10.4
-ghcup-jobs: >= 9.2 || > 8.10.4 && < 9.0
-
--- Switch of tests for 9.2 (doctest not yet supported)
-tests: < 9.2
+-- -- Switch of tests for 9.2 (doctest not yet supported)
+-- tests: < 9.2
 
 allow-failures: >= 9.2
 

--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -34,7 +34,7 @@ tested-with:
   GHC == 8.6.5
   GHC == 8.8.4
   GHC == 8.10.7
-  GHC == 9.0.1
+  GHC == 9.0.2
   GHC == 9.2.1
 
 Extra-source-files:

--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -44,6 +44,8 @@ Extra-source-files:
   Makefile
   src/BNFC.cf
   src/Makefile
+  stack-9.2.1.yaml
+  stack-9.0.2.yaml
   stack-9.0.1.yaml
   stack-8.10.7.yaml
   stack-8.10.4.yaml

--- a/source/stack-9.0.1.yaml
+++ b/source/stack-9.0.1.yaml
@@ -1,33 +1,33 @@
-resolver: ghc-9.0.1
+resolver: nightly-2022-01-04
 compiler: ghc-9.0.1
 # compiler-check: match-exact
 
-extra-deps:
-- alex-3.2.6
-- cabal-doctest-1.0.8
-- happy-1.20.0
-- string-qq-0.0.4
+# extra-deps:
+# - alex-3.2.6
+# - cabal-doctest-1.0.8
+# - happy-1.20.0
+# - string-qq-0.0.4
 
-# For --test:
-- HUnit-1.6.2.0
-- QuickCheck-2.14.2
-- ansi-terminal-0.11
-- base-compat-0.11.2
-- call-stack-0.4.0
-- clock-0.8.2
-- code-page-0.2.1
-- colour-2.3.5
-- doctest-0.18.1
-- ghc-paths-0.1.0.12@rev:2
-- hspec-2.8.2
-- hspec-core-2.8.2
-- hspec-discover-2.8.2
-- hspec-expectations-0.8.2
-- primitive-0.7.1.0
-- quickcheck-io-0.2.0
-- random-1.2.0
-- setenv-0.1.1.3
-- splitmix-0.1.0.3
-- syb-0.7.2.1
-- temporary-1.3
-- tf-random-0.5
+# # For --test:
+# - HUnit-1.6.2.0
+# - QuickCheck-2.14.2
+# - ansi-terminal-0.11
+# - base-compat-0.11.2
+# - call-stack-0.4.0
+# - clock-0.8.2
+# - code-page-0.2.1
+# - colour-2.3.5
+# - doctest-0.18.1
+# - ghc-paths-0.1.0.12@rev:2
+# - hspec-2.8.2
+# - hspec-core-2.8.2
+# - hspec-discover-2.8.2
+# - hspec-expectations-0.8.2
+# - primitive-0.7.1.0
+# - quickcheck-io-0.2.0
+# - random-1.2.0
+# - setenv-0.1.1.3
+# - splitmix-0.1.0.3
+# - syb-0.7.2.1
+# - temporary-1.3
+# - tf-random-0.5

--- a/source/stack-9.0.1.yaml
+++ b/source/stack-9.0.1.yaml
@@ -1,33 +1,3 @@
 resolver: nightly-2022-01-04
 compiler: ghc-9.0.1
 # compiler-check: match-exact
-
-# extra-deps:
-# - alex-3.2.6
-# - cabal-doctest-1.0.8
-# - happy-1.20.0
-# - string-qq-0.0.4
-
-# # For --test:
-# - HUnit-1.6.2.0
-# - QuickCheck-2.14.2
-# - ansi-terminal-0.11
-# - base-compat-0.11.2
-# - call-stack-0.4.0
-# - clock-0.8.2
-# - code-page-0.2.1
-# - colour-2.3.5
-# - doctest-0.18.1
-# - ghc-paths-0.1.0.12@rev:2
-# - hspec-2.8.2
-# - hspec-core-2.8.2
-# - hspec-discover-2.8.2
-# - hspec-expectations-0.8.2
-# - primitive-0.7.1.0
-# - quickcheck-io-0.2.0
-# - random-1.2.0
-# - setenv-0.1.1.3
-# - splitmix-0.1.0.3
-# - syb-0.7.2.1
-# - temporary-1.3
-# - tf-random-0.5

--- a/source/stack-9.0.2.yaml
+++ b/source/stack-9.0.2.yaml
@@ -1,0 +1,33 @@
+resolver: ghc-9.0.2
+compiler: ghc-9.0.2
+# compiler-check: match-exact
+
+extra-deps:
+- alex-3.2.6
+- cabal-doctest-1.0.8
+- happy-1.20.0
+- string-qq-0.0.4
+
+# For --test:
+- HUnit-1.6.2.0
+- QuickCheck-2.14.2
+- ansi-terminal-0.11
+- base-compat-0.11.2
+- call-stack-0.4.0
+- clock-0.8.2
+- code-page-0.2.1
+- colour-2.3.5
+- doctest-0.18.1
+- ghc-paths-0.1.0.12@rev:2
+- hspec-2.8.2
+- hspec-core-2.8.2
+- hspec-discover-2.8.2
+- hspec-expectations-0.8.2
+- primitive-0.7.1.0
+- quickcheck-io-0.2.0
+- random-1.2.0
+- setenv-0.1.1.3
+- splitmix-0.1.0.3
+- syb-0.7.2.1
+- temporary-1.3
+- tf-random-0.5

--- a/source/stack-9.0.2.yaml
+++ b/source/stack-9.0.2.yaml
@@ -1,33 +1,33 @@
-resolver: ghc-9.0.2
+resolver: nightly-2022-01-27
 compiler: ghc-9.0.2
 # compiler-check: match-exact
 
-extra-deps:
-- alex-3.2.6
-- cabal-doctest-1.0.8
-- happy-1.20.0
-- string-qq-0.0.4
+# extra-deps:
+# - alex-3.2.6
+# - cabal-doctest-1.0.8
+# - happy-1.20.0
+# - string-qq-0.0.4
 
-# For --test:
-- HUnit-1.6.2.0
-- QuickCheck-2.14.2
-- ansi-terminal-0.11
-- base-compat-0.11.2
-- call-stack-0.4.0
-- clock-0.8.2
-- code-page-0.2.1
-- colour-2.3.5
-- doctest-0.18.1
-- ghc-paths-0.1.0.12@rev:2
-- hspec-2.8.2
-- hspec-core-2.8.2
-- hspec-discover-2.8.2
-- hspec-expectations-0.8.2
-- primitive-0.7.1.0
-- quickcheck-io-0.2.0
-- random-1.2.0
-- setenv-0.1.1.3
-- splitmix-0.1.0.3
-- syb-0.7.2.1
-- temporary-1.3
-- tf-random-0.5
+# # For --test:
+# - HUnit-1.6.2.0
+# - QuickCheck-2.14.2
+# - ansi-terminal-0.11
+# - base-compat-0.11.2
+# - call-stack-0.4.0
+# - clock-0.8.2
+# - code-page-0.2.1
+# - colour-2.3.5
+# - doctest-0.18.1
+# - ghc-paths-0.1.0.12@rev:2
+# - hspec-2.8.2
+# - hspec-core-2.8.2
+# - hspec-discover-2.8.2
+# - hspec-expectations-0.8.2
+# - primitive-0.7.1.0
+# - quickcheck-io-0.2.0
+# - random-1.2.0
+# - setenv-0.1.1.3
+# - splitmix-0.1.0.3
+# - syb-0.7.2.1
+# - temporary-1.3
+# - tf-random-0.5

--- a/source/stack-9.2.1.yaml
+++ b/source/stack-9.2.1.yaml
@@ -1,0 +1,33 @@
+resolver: ghc-9.2.1
+compiler: ghc-9.2.1
+# compiler-check: match-exact
+
+extra-deps:
+- alex-3.2.6
+- cabal-doctest-1.0.9
+- happy-1.20.0
+- string-qq-0.0.4
+
+# For --test:
+- HUnit-1.6.2.0
+- QuickCheck-2.14.2
+- ansi-terminal-0.11
+- base-compat-0.12.1
+- call-stack-0.4.0
+- clock-0.8.2
+- code-page-0.2.1
+- colour-2.3.6
+- doctest-0.20.0
+- ghc-paths-0.1.0.12@rev:3
+- hspec-2.9.4
+- hspec-core-2.9.4
+- hspec-discover-2.9.4
+- hspec-expectations-0.8.2
+- primitive-0.7.3.0
+- quickcheck-io-0.2.0
+- random-1.2.1
+- setenv-0.1.1.3
+- splitmix-0.1.0.4
+- syb-0.7.2.1
+- temporary-1.3
+- tf-random-0.5

--- a/stack-9.0.2.yaml
+++ b/stack-9.0.2.yaml
@@ -1,0 +1,7 @@
+resolver: nightly-2022-01-27
+compiler: ghc-9.0.2
+compiler-check: match-exact
+
+packages:
+- source
+- testing

--- a/testing/bnfc-system-tests.cabal
+++ b/testing/bnfc-system-tests.cabal
@@ -54,7 +54,7 @@ tested-with:         GHC == 8.2.2
                      GHC == 8.6.5
                      GHC == 8.8.4
                      GHC == 8.10.7
-                     GHC == 9.0.1
+                     GHC == 9.0.2
                      GHC == 9.2.1
 
 executable bnfc-system-tests
@@ -89,7 +89,6 @@ executable bnfc-system-tests
     , HTF         >= 0.14.0.5
       -- HTF-0.14.0.3 does not build with random-1.2
     , random
-      -- random < 1.2
     , string-qq
 
   -- Directories containing source files.


### PR DESCRIPTION
- Stack.yaml files for GHC 9.2.1, 9.0.2 and 9.0.1 (updated to nightly)
- Bump CI from GHC 9.0.1 to 9.0.2