### PR TITLE
Haskell: emit `{-# LANGUAGE Safe #-}` (and `Trustworthy` in Lex/Par.hs)

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.9.5
 
 Unreleased
+* Haskell: label produced code as `Safe` (and parser as `Trustworthy`)
 
 # 2.9.4
 

--- a/source/src/BNFC/Backend/Haskell.hs
+++ b/source/src/BNFC/Backend/Haskell.hs
@@ -298,7 +298,9 @@ makefile opts cf makeFile = vcat
 
 testfile :: Options -> CF -> String
 testfile opts cf = unlines $ concat $
-  [ [ "-- | Program to test parser."
+  [ languageSafe
+  , [ ""
+    , "-- | Program to test parser."
     , ""
     , "module Main where"
     , ""

--- a/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAlex3.hs
@@ -41,6 +41,7 @@ prelude name tokenText = concat
     , "{-# OPTIONS_GHC -w #-}"
     , ""
     , "{-# LANGUAGE PatternSynonyms #-}"
+    , "{-# LANGUAGE Trustworthy #-}"
     , ""
     , "module " ++ name ++ " where"
     , ""

--- a/source/src/BNFC/Backend/Haskell/CFtoHappy.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoHappy.hs
@@ -63,7 +63,9 @@ header modName absName lexName tokenText eps = unlines $ concat
   [ [ "-- Parser definition for use with Happy"
     , "{"
     , "{-# OPTIONS_GHC -fno-warn-incomplete-patterns -fno-warn-overlapping-patterns #-}"
+    , ""
     , "{-# LANGUAGE PatternSynonyms #-}"
+    , "{-# LANGUAGE Trustworthy #-}"
     , ""
     , "module " ++ modName
     , "  ( happyError"

--- a/source/src/BNFC/Backend/Haskell/CFtoLayout.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoLayout.hs
@@ -14,6 +14,7 @@ import Data.Maybe                 ( fromMaybe, mapMaybe )
 import BNFC.CF
 import BNFC.PrettyPrint
 import BNFC.Utils                 ( caseMaybe, for, whenJust )
+import BNFC.Backend.Haskell.Utils ( languageSafe )
 
 data TokSymbol = TokSymbol String Int
   deriving Show
@@ -28,7 +29,9 @@ cf2Layout layName lexName cf = unlines $ concat
     , "{-# LANGUAGE LambdaCase #-}"
     , "{-# LANGUAGE PatternGuards #-}"
     , "{-# LANGUAGE OverloadedStrings #-}"
-    , ""
+    ]
+  , languageSafe
+  , [ ""
     , "module " ++ layName ++ " where"
     , ""
     , "import Prelude"

--- a/source/src/BNFC/Backend/Haskell/CFtoPrinter.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoPrinter.hs
@@ -60,17 +60,15 @@ prologue :: TokenText -> Bool -> String -> [AbsMod] -> CF -> [Doc]
 prologue tokenText useGadt name absMod cf = map text $ concat
   [ [ "{-# LANGUAGE CPP #-}"
     , "{-# LANGUAGE FlexibleInstances #-}"
-    , "{-# LANGUAGE LambdaCase #-}"
     ]
   , [ "{-# LANGUAGE GADTs #-}"                | useGadt ]
+  , [ "{-# LANGUAGE LambdaCase #-}" ]
   , [ "#if __GLASGOW_HASKELL__ <= 708"
     , "{-# LANGUAGE OverlappingInstances #-}"
     , "#endif"
     ]
+  , languageSafe
   , [ ""
-    -- -- WAS: Needed for precedence category lists, e.g. @[Exp2]@:
-    -- , "{-# OPTIONS_GHC -fno-warn-incomplete-patterns #-}"
-    -- , ""
     , "-- | Pretty-printer for " ++ takeWhile ('.' /=) name ++ "."
     , ""
     , "module " ++ name +++ "where"

--- a/source/src/BNFC/Backend/Haskell/CFtoTemplate.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoTemplate.hs
@@ -13,7 +13,7 @@ import Prelude hiding ((<>))
 import BNFC.CF
 import BNFC.PrettyPrint
 import BNFC.Utils                 ( ModuleName )
-import BNFC.Backend.Haskell.Utils ( catvars, noWarnUnusedMatches )
+import BNFC.Backend.Haskell.Utils ( catvars, languageSafe, noWarnUnusedMatches )
 
 cf2Template :: ModuleName -> ModuleName -> Bool -> CF -> String
 cf2Template skelName absName functor cf = unlines $ concat
@@ -21,6 +21,9 @@ cf2Template skelName absName functor cf = unlines $ concat
     , ""
     , noWarnUnusedMatches
     , ""
+    ]
+  , languageSafe
+  , [ ""
     , "module "++ skelName ++ " where"
     , ""
     , "import Prelude (($), Either(..), String, (++), Show, show)"

--- a/source/src/BNFC/Backend/Haskell/MkErrM.hs
+++ b/source/src/BNFC/Backend/Haskell/MkErrM.hs
@@ -10,12 +10,14 @@
 
 module BNFC.Backend.Haskell.MkErrM where
 
+import BNFC.Backend.Haskell.Utils (languageSafe)
 import BNFC.PrettyPrint
 
 mkErrM :: String -> Doc
-mkErrM errMod = vcat
-    [ "{-# LANGUAGE CPP #-}"
-    , ""
+mkErrM errMod = vcat $ concat
+  [ [ "{-# LANGUAGE CPP #-}" ]
+  , languageSafe
+  , [ ""
     , "#if __GLASGOW_HASKELL__ >= 708"
     , "---------------------------------------------------------------------------"
     , "-- Pattern synonyms exist since ghc 7.8."
@@ -104,3 +106,4 @@ mkErrM errMod = vcat
     , ""
     , "#endif"
     ]
+  ]

--- a/source/src/BNFC/Backend/Haskell/Utils.hs
+++ b/source/src/BNFC/Backend/Haskell/Utils.hs
@@ -5,7 +5,7 @@ module BNFC.Backend.Haskell.Utils
   ( comment, commentWithEmacsModeHint
   , posType, posConstr, noPosConstr
   , hasPositionClass, hasPositionMethod
-  , noWarnUnusedMatches
+  , languageSafe, noWarnUnusedMatches
   , parserName
   , hsReservedWords, avoidReservedWords, mkDefName
   , typeToHaskell, typeToHaskell'
@@ -42,6 +42,13 @@ noWarnUnusedMatches =
   "{-# OPTIONS_GHC -fno-warn-unused-matches #-}"
   -- ALT: only from GHC 8
   -- "{-# OPTIONS_GHC -Wno-unused-matches #-}"
+
+languageSafe :: IsString a => [a]
+languageSafe =
+  [ "{-# LANGUAGE Safe #-}"
+  , "{-# LANGUAGE NoGeneralizedNewtypeDeriving #-}"
+  , "  -- needed with Safe in language GHC2021, GHC 9.2 issue #19605"
+  ]
 
 -- * Names for position data type.
 

--- a/source/src/BNFC/Backend/HaskellGADT.hs
+++ b/source/src/BNFC/Backend/HaskellGADT.hs
@@ -12,7 +12,7 @@ module BNFC.Backend.HaskellGADT (makeHaskellGadt) where
 import BNFC.Options
 import BNFC.Backend.Base hiding (Backend)
 import BNFC.Backend.Haskell.HsOpts
-import BNFC.Backend.Haskell.Utils (comment, commentWithEmacsModeHint)
+import BNFC.Backend.Haskell.Utils (comment, commentWithEmacsModeHint, languageSafe)
 import BNFC.CF
 import BNFC.Backend.Haskell.CFtoHappy
 import BNFC.Backend.Haskell.CFtoAlex3
@@ -61,7 +61,7 @@ makeHaskellGadt opts cf = do
   mkHsFileHint x = mkfile x commentWithEmacsModeHint
 
 composOp :: String -> String
-composOp composOpMod = unlines
+composOp composOpMod = unlines $ languageSafe ++
     [
      "{-# LANGUAGE Rank2Types, PolyKinds #-}",
      "module " ++ composOpMod ++ " (Compos(..),composOp,composOpM,composOpM_,composOpMonoid,",

--- a/source/src/BNFC/Backend/HaskellGADT/CFtoAbstractGADT.hs
+++ b/source/src/BNFC/Backend/HaskellGADT/CFtoAbstractGADT.hs
@@ -22,11 +22,15 @@ cf2Abstract :: TokenText -> String -> CF -> String -> String
 cf2Abstract tokenText name cf composOpMod = unlines $ concat $
   [ [ "-- For GHC version 7.10 or higher"
     , ""
-    , "{-# LANGUAGE GADTs, KindSignatures, DataKinds #-}"
+    , "{-# LANGUAGE DataKinds #-}"
     ]
   , [ "{-# LANGUAGE EmptyCase #-}" | emptyTree ]
-  , [ "{-# LANGUAGE LambdaCase #-}"
-    , ""
+  , [ "{-# LANGUAGE GADTs #-}"
+    , "{-# LANGUAGE KindSignatures #-}"
+    , "{-# LANGUAGE LambdaCase #-}"
+    ]
+  , languageSafe
+  , [ ""
     , "{-# OPTIONS_GHC -fno-warn-unused-binds #-}"
       -- unused-local-binds would be sufficient, but parses only from GHC 8.0
     , "{-# OPTIONS_GHC -fno-warn-unused-imports #-}"

--- a/source/src/BNFC/Backend/HaskellGADT/CFtoTemplateGADT.hs
+++ b/source/src/BNFC/Backend/HaskellGADT/CFtoTemplateGADT.hs
@@ -12,14 +12,16 @@ import Data.List  ( groupBy )
 import BNFC.CF
 import BNFC.Utils ( ModuleName, (+++) )
 
-import BNFC.Backend.Haskell.Utils ( noWarnUnusedMatches )
+import BNFC.Backend.Haskell.Utils ( languageSafe, noWarnUnusedMatches )
 import BNFC.Backend.HaskellGADT.HaskellGADTCommon
 
 cf2Template :: ModuleName -> ModuleName -> CF -> String
 cf2Template skelName absName cf = unlines $ concat
-  [ [ "{-# LANGUAGE GADTs #-}"
-    , "{-# LANGUAGE EmptyCase #-}"
-    , ""
+  [ [ "{-# LANGUAGE EmptyCase #-}"
+    , "{-# LANGUAGE GADTs #-}"
+    ]
+  , languageSafe
+  , [ ""
     , noWarnUnusedMatches
     , ""
     , "module "++ skelName ++ " where"


### PR DESCRIPTION
Haskell: emit `{-# LANGUAGE Safe #-}` (and `Trustworthy` in generated `Lex`/`Par.hs`)
Had to get rid of `GeneralizedNewtypeDeriving` extension in generated `Abs.hs`.