### PR TITLE
Fix #427: Added missing lpthread flag in Makefile

### DIFF
--- a/source/src/BNFC/Backend/Haskell.hs
+++ b/source/src/BNFC/Backend/Haskell.hs
@@ -175,6 +175,7 @@ makefileHeader Options{ agda, glr } = vcat
   , when agda $
     "AGDA       = agda"
   , "GHC        = ghc"
+  , "GHC_OPTS   = -lpthread"
   , "HAPPY      = happy"
   , hsep $ concat
     [ [ "HAPPY_OPTS = --array --info" ]
@@ -262,7 +263,7 @@ makefile opts cf makeFile = vcat
 
   -- | Rule to build Haskell test parser.
   testParserRule :: Doc
-  testParserRule = Makefile.mkRule tgt deps [ "${GHC} -lpthread ${GHC_OPTS} $@" ]
+  testParserRule = Makefile.mkRule tgt deps [ "${GHC} ${GHC_OPTS} $@" ]
     where
     tgt :: String
     tgt = tFileExe opts

--- a/source/src/BNFC/Backend/Haskell.hs
+++ b/source/src/BNFC/Backend/Haskell.hs
@@ -262,7 +262,7 @@ makefile opts cf makeFile = vcat
 
   -- | Rule to build Haskell test parser.
   testParserRule :: Doc
-  testParserRule = Makefile.mkRule tgt deps [ "${GHC} ${GHC_OPTS} $@" ]
+  testParserRule = Makefile.mkRule tgt deps [ "${GHC} -lpthread ${GHC_OPTS} $@" ]
     where
     tgt :: String
     tgt = tFileExe opts


### PR DESCRIPTION
There was a `-lpthread` flag missing in the Makefile for the Haskell parser that lead to a linking error. I added it.  