### PR TITLE
Fix #431: escape space character in C-family lexer definitions

### DIFF
--- a/source/src/BNFC/Backend/C/RegToFlex.hs
+++ b/source/src/BNFC/Backend/C/RegToFlex.hs
@@ -81,4 +81,4 @@ escapeChar c
   | otherwise               = showLitChar c ""
   where
   reserved :: String
-  reserved = "$+-*=<>[](){}!?.,;:^~|&%#/\\$_@\""
+  reserved = " $+-*=<>[](){}!?.,;:^~|&%#/\\$_@\""

--- a/testing/regression-tests/256_Regex/good01.in
+++ b/testing/regression-tests/256_Regex/good01.in
@@ -1,1 +1,1 @@
-[x:4] /\ 'funky+identifier-umlaute:äöüß//\%#FOO and Un]'
+' x10 0' [x:4] /\ 'funky+identifier-umlaute:äöüß//\%#FOO and Un]'

--- a/testing/regression-tests/256_Regex/good01.out
+++ b/testing/regression-tests/256_Regex/good01.out
@@ -3,8 +3,8 @@ Parse Successful!
 
 [Abstract Syntax]
 
-Start (Name "[x:4]") (Name "'funky+identifier-umlaute:\228\246\252\223//\\%#FOO") (Triple "Un]'")
+Start (SpaceInAlts "' x10 0'") (Name "[x:4]") (Name "'funky+identifier-umlaute:\228\246\252\223//\\%#FOO") (Triple "Un]'")
 
 [Linearized tree]
 
-[x:4] /\ 'funky+identifier-umlaute:äöüß//\%#FOO and Un]'
+' x10 0' [x:4] /\ 'funky+identifier-umlaute:äöüß//\%#FOO and Un]'

--- a/testing/regression-tests/256_Regex/test.cf
+++ b/testing/regression-tests/256_Regex/test.cf
@@ -1,6 +1,10 @@
 -- Issue #110: backslash in keyword
 
-Start. Main ::= Name "/\\" Name "and" Triple;
+Start. Main ::= SpaceInAlts Name "/\\" Name "and" Triple;
+
+-- Issue #431: whitespace in character alternatives
+
+token SpaceInAlts '\'' ["01x "]* '\'' ;
 
 -- Issue #319: quotation rule in ANTLR lexer definition
 


### PR DESCRIPTION
Fix #431: escape space character in C-family lexer definitions.