### PR TITLE
Fix: #437: enable doctest for GHC 9.6.1 in Haskell-CI

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230304
+# version: 0.15.20230312
 #
-# REGENDATA ("0.15.20230304",["github","cabal.project"])
+# REGENDATA ("0.15.20230312",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -34,11 +34,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230302
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230302
+            compilerVersion: 9.6.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -99,9 +99,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
@@ -109,8 +108,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -128,20 +126,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -170,22 +168,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
-          cat >> $CABAL_CONFIG <<EOF
-          program-default-options
-            ghc-options: $GHCJOBS +RTS -M3G -RTS
-          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -212,7 +194,7 @@ jobs:
         run: |
           touch cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/source" >> cabal.project
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/testing" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/testing" >> cabal.project ; fi
           cat cabal.project
       - name: sdist
         run: |
@@ -232,16 +214,13 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_BNFC}" >> cabal.project
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then echo "packages: ${PKGDIR_bnfc_system_tests}" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "packages: ${PKGDIR_bnfc_system_tests}" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package BNFC" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then echo "package bnfc-system-tests" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package bnfc-system-tests" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(BNFC|bnfc-system-tests)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -265,6 +244,12 @@ jobs:
       - name: build
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
+      - name: install doctest
+        run: |
+          $CABAL v2-install $ARG_COMPILER doctest --overwrite-policy=always
+      - name: doctests
+        run: |
+          $CABAL v2-repl BNFC --with-ghc-pkg=$HCPKG -w doctest --repl-options=-fno-warn-type-defaults
       - name: tests
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
@@ -272,8 +257,8 @@ jobs:
         run: |
           cd ${PKGDIR_BNFC} || false
           ${CABAL} -vnormal check
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then cd ${PKGDIR_bnfc_system_tests} || false ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90600)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cd ${PKGDIR_bnfc_system_tests} || false ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
       - name: haddock
         run: |
           $CABAL v2-haddock --disable-documentation $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -79,20 +79,17 @@ jobs:
         # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
 
       - name: Cache dependencies
-        # if:   runner.os == 'Linux'
         uses: actions/cache@v3
-        with:
-          path: ${{ steps.haskell-setup.outputs.stack-root }}
-          # A unique cache is used for each stack.yaml.
-          # Append the commit sha to ensure the cache is always written.
-          key: ${{ env.key }}-${{ github.sha }}
-          restore-keys: ${{ env.key }}-
         env:
-          key: ${{ runner.os }}-${{ env.STACK_VER }}-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+          key: ${{ runner.os }}-stack-${{ env.STACK_VER }}-ghc-${{ env.GHC_VER }}-
           ## Just stack.yaml is actually not correct, better would be stack.yaml.lock,
           ## but we do not commit this file.  As a workaround, one could include the .cabal file,
           ## which tracks the dependencies (albeit in our case not precisely).
           # key: ${{ runner.os }}-${{ env.STACK_VER }}-${{ hashFiles('source/BNFC.cabal', format('stack-{0}.yaml', env.GHC_VER)) }}
+        with:
+          path: ${{ steps.haskell-setup.outputs.stack-root }}
+          key:          ${{ env.key }}-resolver-${{ hashFiles(format('stack-{0}.yaml', env.GHC_VER)) }}
+          restore-keys: ${{ env.key }}-
 
       - name: Build dependencies.
         run: stack build ${{ env.TARGET }} ${{ env.STACK_FLAGS }} --only-dependencies

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -60,21 +60,21 @@ jobs:
           echo "cabal-exe   = ${{ steps.haskell-setup.outputs.cabal-exe   }}"
           echo "stack-exe   = ${{ steps.haskell-setup.outputs.stack-exe   }}"
           echo "stack-root  = ${{ steps.haskell-setup.outputs.stack-root  }}"
-          export GHC_VER=$(ghc --numeric-version)
-          export CABAL_VER=$(cabal --numeric-version)
-          export STACK_VER=$(stack --numeric-version)
-          export STACK_FLAGS="--stack-yaml stack-${GHC_VER}.yaml --system-ghc --no-terminal --color always"
-          export TARGET=$(if [ "${{ runner.os }}" == "Windows" ]; then echo ":bnfc"; fi)
+          GHC_VER=$(ghc --numeric-version)
+          CABAL_VER=$(cabal --numeric-version)
+          STACK_VER=$(stack --numeric-version)
+          STACK_FLAGS="--stack-yaml stack-${GHC_VER}.yaml --system-ghc --no-terminal --color always"
+          TARGET=$(if [ "${{ runner.os }}" == "Windows" ]; then echo ":bnfc"; fi)
           echo "GHC_VER     = ${GHC_VER}"
           echo "CABAL_VER   = ${CABAL_VER}"
           echo "STACK_VER   = ${STACK_VER}"
           echo "STACK_FLAGS = ${STACK_FLAGS}"
           echo "TARGET      = ${TARGET}"
-          echo "GHC_VER=${GHC_VER}"          >> ${GITHUB_ENV}
-          echo "CABAL_VER=${CABAL_VER}"      >> ${GITHUB_ENV}
-          echo "STACK_VER=${STACK_VER}"      >> ${GITHUB_ENV}
-          echo "STACK_FLAGS=${STACK_FLAGS}"  >> ${GITHUB_ENV}
-          echo "TARGET=${TARGET}"            >> ${GITHUB_ENV}
+          echo "GHC_VER=${GHC_VER}"          >> "${GITHUB_ENV}"
+          echo "CABAL_VER=${CABAL_VER}"      >> "${GITHUB_ENV}"
+          echo "STACK_VER=${STACK_VER}"      >> "${GITHUB_ENV}"
+          echo "STACK_FLAGS=${STACK_FLAGS}"  >> "${GITHUB_ENV}"
+          echo "TARGET=${TARGET}"            >> "${GITHUB_ENV}"
         # Stack build TARGET restriction on Windows as it cannot build the 'testing' package.
         # From now on, use env.{GHC|CABAL}_VER rather than matrix.{ghc|cabal}-ver!
 
@@ -110,11 +110,11 @@ jobs:
 
       - name: Run bnfc.
         run: |
-          export BNFC_EXE=$(stack path --local-install-root ${{ env.STACK_FLAGS }})/bin/bnfc
-          export BNFC_VERSION=$(${BNFC_EXE} --numeric-version)
+          BNFC_EXE=$(stack path --local-install-root ${{ env.STACK_FLAGS }})/bin/bnfc
+          BNFC_VERSION=$("${BNFC_EXE}" --numeric-version)
           # Save env variables for the next steps
-          echo "BNFC_EXE=${BNFC_EXE}"         >> ${GITHUB_ENV}
-          echo "BNFC_VERSION=${BNFC_VERSION}" >> ${GITHUB_ENV}
+          echo "BNFC_EXE=${BNFC_EXE}"         >> "${GITHUB_ENV}"
+          echo "BNFC_VERSION=${BNFC_VERSION}" >> "${GITHUB_ENV}"
 
       ## Release
       ########################################################################
@@ -125,8 +125,8 @@ jobs:
           startsWith(github.ref, 'refs/tags/v')
           && matrix.ghc == '9.4.4'
         run: |
-          export DIST_TGZ=$(cabal sdist source | tail -1)
-          echo "DIST_TGZ=${DIST_TGZ}" >> ${GITHUB_ENV}
+          DIST_TGZ=$(cabal sdist source | tail -1)
+          echo "DIST_TGZ=${DIST_TGZ}" >> "${GITHUB_ENV}"
 
       - name: Source tarball release.
         if: >-
@@ -145,10 +145,10 @@ jobs:
           && runner.os == 'Linux'
           && matrix.ghc == '9.4.4'
         run: |
-          export BNFC_BIN=bnfc-${BNFC_VERSION}-linux.binary
-          cp -p ${BNFC_EXE} ${BNFC_BIN}
+          BNFC_BIN=bnfc-${BNFC_VERSION}-linux.binary
+          cp -p "${BNFC_EXE}" "${BNFC_BIN}"
           # Save env variables for the next step
-          echo "BNFC_BIN=${BNFC_BIN}" >> ${GITHUB_ENV}
+          echo "BNFC_BIN=${BNFC_BIN}" >> "${GITHUB_ENV}"
 
       - name: Linux release.
         if: >-
@@ -167,23 +167,23 @@ jobs:
           startsWith(github.ref, 'refs/tags/v')
           && runner.os == 'macOS'
         run: |
-          export BNFC_BIN=bnfc-${BNFC_VERSION}-mac.binary
-          export BNFC_PKG=bnfc-${BNFC_VERSION}-mac.pkg
+          BNFC_BIN=bnfc-${BNFC_VERSION}-mac.binary
+          BNFC_PKG=bnfc-${BNFC_VERSION}-mac.pkg
           # Raw Mac binary
-          cp -p ${BNFC_EXE} ${BNFC_BIN}
+          cp -p "${BNFC_EXE}" "${BNFC_BIN}"
           # Build Mac package
           mkdir -p tmp/usr/local/bin
-          cp -p ${BNFC_EXE} tmp/usr/local/bin/bnfc
+          cp -p "${BNFC_EXE}" tmp/usr/local/bin/bnfc
           pkgbuild \
             --root tmp \
             --identifier com.digitalgrammars.bnfc.pkg \
-            --version ${BNFC_VERSION} \
+            --version "${BNFC_VERSION}" \
             --install-location / \
             --ownership recommended \
-            ${BNFC_PKG}
+            "${BNFC_PKG}"
           # Save env variables for the next step
-          echo "BNFC_BIN=${BNFC_BIN}" >> ${GITHUB_ENV}
-          echo "BNFC_PKG=${BNFC_PKG}" >> ${GITHUB_ENV}
+          echo "BNFC_BIN=${BNFC_BIN}" >> "${GITHUB_ENV}"
+          echo "BNFC_PKG=${BNFC_PKG}" >> "${GITHUB_ENV}"
 
       - name: Mac release.
         if: >-
@@ -204,10 +204,10 @@ jobs:
           && runner.os == 'Windows'
         shell: bash
         run: |
-          export BNFC_VER_EXE=bnfc-${BNFC_VERSION}.exe
-          cp -p ${BNFC_EXE}.exe ${BNFC_VER_EXE}
+          BNFC_VER_EXE=bnfc-${BNFC_VERSION}.exe
+          cp -p "${BNFC_EXE}.exe" "${BNFC_VER_EXE}"
           # Save env variables for the next step
-          echo "BNFC_VER_EXE=${BNFC_VER_EXE}" >> ${GITHUB_ENV}
+          echo "BNFC_VER_EXE=${BNFC_VER_EXE}" >> "${GITHUB_ENV}"
 
       - name: Windows release.
         if: >-

--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -32,7 +32,7 @@ Description:
 
 -- Support range when build with cabal
 tested-with:
-  GHC == 9.6.0
+  GHC == 9.6.1
   GHC == 9.4.4
   GHC == 9.2.7
   GHC == 9.0.2

--- a/testing/bnfc-system-tests.cabal
+++ b/testing/bnfc-system-tests.cabal
@@ -49,14 +49,16 @@ build-type:          Simple
 -- Constraint on the version of Cabal needed to build this package.
 cabal-version:       >=1.10
 
-tested-with:         GHC == 8.2.2
-                     GHC == 8.4.4
-                     GHC == 8.6.5
-                     GHC == 8.8.4
-                     GHC == 8.10.7
-                     GHC == 9.0.2
-                     GHC == 9.2.7
-                     GHC == 9.4.4
+tested-with:
+    GHC == 9.6.1
+    GHC == 9.4.4
+    GHC == 9.2.7
+    GHC == 9.0.2
+    GHC == 8.10.7
+    GHC == 8.8.4
+    GHC == 8.6.5
+    GHC == 8.4.4
+    GHC == 8.2.2
 
 executable bnfc-system-tests
   -- .hs or .lhs file containing the Main module.


### PR DESCRIPTION
Fix #437:
- reenable doctest in Haskell-CI
- include GHC 9.6.1 in Haskell-CI for bnfc-system-tests
- more conservative caching in stack CI