### PR TITLE
Simplify definition of internal function `columns`

### DIFF
--- a/source/src/BNFC/Utils.hs
+++ b/source/src/BNFC/Utils.hs
@@ -32,7 +32,7 @@ import Control.Arrow   ((&&&))
 import Control.DeepSeq (rnf)
 
 import Data.Char
-import Data.List          (intercalate)
+import Data.List          (intercalate, transpose)
 import Data.List.NonEmpty (pattern (:|))
 import Data.Map           (Map)
 #if !MIN_VERSION_base(4,11,0)
@@ -171,13 +171,7 @@ table sep m = map (intercalate sep . zipWith pad widths) m
   widths = columns maximum $ map (map length) m
   -- Aggregate columns (works even for a ragged matrix with rows of different length).
   columns :: ([a] -> b) -> [[a]] -> [b]
-  columns f rows =
-    -- Take the values of the first column
-    case concat (map (take 1) rows) of
-      -- Matrix was empty:
-      [] -> []
-      -- Matrix was non-empty:
-      col -> f col : columns f (map (drop 1) rows)
+  columns f = map f . transpose
 
 -- * List utilities
 

--- a/source/src/BNFC/Utils.hs
+++ b/source/src/BNFC/Utils.hs
@@ -168,10 +168,7 @@ table sep m = map (intercalate sep . zipWith pad widths) m
   where
   -- Column widths.
   widths :: [Int]
-  widths = columns maximum $ map (map length) m
-  -- Aggregate columns (works even for a ragged matrix with rows of different length).
-  columns :: ([a] -> b) -> [[a]] -> [b]
-  columns f = map f . transpose
+  widths = map maximum $ transpose $ map (map length) m
 
 -- * List utilities
 


### PR DESCRIPTION
The internal function columns is building a list with the first element of each sublist, applying an auxiliary function f to it, and then proceeding recursively with the tails of all lists.

This is the same as transposing the list of lists so that all the first elements of the sublists are grouped together, all the second elements are grouped together, and so on, and then applying f to each resulting sublist.

This commit simplifies the definition of columns by using Data.List.transpose.