### PR TITLE
Simplify code

### DIFF
--- a/source/src/BNFC/Backend/Agda.hs
+++ b/source/src/BNFC/Backend/Agda.hs
@@ -582,7 +582,6 @@ prettyData style d cs = vcat $ concat
   [ [ hsep [ "data", text d, colon, "Set", "where" ] ]
   , mkTSTable $ map (prettyConstructor style d) cs
   ]
-  where
 
 mkTSTable :: [(Doc,Doc)] -> [Doc]
 mkTSTable = map (nest 2 . text) . table " : " . map mkRow

--- a/source/src/BNFC/Backend/Agda.hs
+++ b/source/src/BNFC/Backend/Agda.hs
@@ -757,7 +757,7 @@ printers :: ModuleName -> [Cat] -> Doc
 printers _amod []   = empty
 printers  amod cats = vsep
   [ "-- Binding the pretty printers."
-  , vcat $ "postulate" : mkTSTable (map (prettyTySig) cats)
+  , vcat $ "postulate" : mkTSTable (map prettyTySig cats)
   , vcat $ map pragmaBind cats
   ]
   where
@@ -983,7 +983,7 @@ agdaMainContents mod lmod amod pmod layout c = vcat
   , "module" <+> text mod <+> "where"
   , when layout "\nopen import Agda.Builtin.Bool using (true)"
   , "open import" <+> text lmod
-  , "open import" <+> text amod <+> "using" <+> parens (printer)
+  , "open import" <+> text amod <+> "using" <+> parens printer
   , "open import" <+> text pmod <+> "using" <+> parens ("Err;" <+> parser)
   , ""
   , "main : IO ⊤"

--- a/source/src/BNFC/Backend/C/CFtoCAbs.hs
+++ b/source/src/BNFC/Backend/C/CFtoCAbs.hs
@@ -226,7 +226,7 @@ prDataH rp (cat, rules)
     mem = identCat (normCatOfList cat)
     prKind (fun, _) = "is_" ++ fun
     prUnion (_, []) = ""
-    prUnion (fun, cats) = "    struct { " ++ (render $ prInstVars (getVars cats)) ++ " } " ++ (memName fun) ++ ";\n"
+    prUnion (fun, cats) = "    struct { " ++ (render $ prInstVars (getVars cats)) ++ " } " ++ memName fun ++ ";\n"
 
 
 -- | Interface definitions for rules vary on the type of rule.

--- a/source/src/BNFC/Backend/C/CFtoFlexC.hs
+++ b/source/src/BNFC/Backend/C/CFtoFlexC.hs
@@ -352,6 +352,6 @@ lexMultiComment (b,e) comment = vcat
 -- | Helper function that escapes characters in strings.
 escapeChars :: String -> String
 escapeChars [] = []
-escapeChars ('\\':xs) = '\\' : ('\\' : (escapeChars xs))
-escapeChars ('\"':xs) = '\\' : ('\"' : (escapeChars xs))
-escapeChars (x:xs) = x : (escapeChars xs)
+escapeChars ('\\':xs) = '\\' : ('\\' : escapeChars xs)
+escapeChars ('\"':xs) = '\\' : ('\"' : escapeChars xs)
+escapeChars (x:xs) = x : escapeChars xs

--- a/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
@@ -90,11 +90,11 @@ prDataH  user (cat, rules) =
 
 --Interface definitions for rules vary on the type of rule.
 prRuleH :: [UserDef] -> Cat -> (Fun, [Cat]) -> String
-prRuleH user c (fun, cats) =
-    if isNilFun fun || isOneFun fun
-    then ""  --these are not represented in the AbSyn
-    else if isConsFun fun
-    then --this is the linked list case.
+prRuleH user c (fun, cats)
+  | isNilFun fun || isOneFun fun
+  = ""  --these are not represented in the AbSyn
+  | isConsFun fun
+  = --this is the linked list case.
     unlines
     [
      "class" +++ c' +++ ": public Visitable",
@@ -113,8 +113,8 @@ prRuleH user c (fun, cats) =
      "  void swap(" ++ c' +++ "&);",
      "};"
     ]
-    else --a standard rule
-    unlines
+  | otherwise --a standard rule
+  = unlines
     [
      "class" +++ fun +++ ": public" +++ super,
      "{",
@@ -249,11 +249,11 @@ prDataC user (cat, rules) = concatMap (prRuleC user cat) rules
 
 --Classes for rules vary based on the type of rule.
 prRuleC :: [UserDef] -> Cat -> (String, [Cat]) -> String
-prRuleC user c (fun, cats) =
-    if isNilFun fun || isOneFun fun
-    then ""  --these are not represented in the AbSyn
-    else if isConsFun fun
-    then --this is the linked list case.
+prRuleC user c (fun, cats)
+  | isNilFun fun || isOneFun fun
+  = ""  --these are not represented in the AbSyn
+  | isConsFun fun
+  = --this is the linked list case.
     unlines
     [
      "/********************   " ++ c' ++ "    ********************/",
@@ -265,8 +265,8 @@ prRuleC user c (fun, cats) =
      prCloneC user c' vs,
      ""
     ]
-    else --a standard rule
-    unlines
+  | otherwise --a standard rule
+  = unlines
     [
      "/********************   " ++ fun ++ "    ********************/",
      render $ prConstructorC user fun vs cats,

--- a/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
+++ b/source/src/BNFC/Backend/CPP/NoSTL/CFtoCPPAbs.hs
@@ -103,7 +103,7 @@ prRuleH user c (fun, cats) =
      render $ nest 2 $ prInstVars user vs,
      "  " ++ c' ++ "(const" +++ c' +++ "&);",
      "  " ++ c' ++ " &operator=(const" +++ c' +++ "&);",
-     "  " ++ c' ++ "(" ++ (prConstructorH 1 vs) ++ ");",
+     "  " ++ c' ++ "(" ++ prConstructorH 1 vs ++ ");",
      "  " ++ c' ++ "(" ++ mem +++ memstar ++ "p);",
      prDestructorH c',
      "  " ++ c' ++ "* reverse();",

--- a/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
@@ -18,7 +18,7 @@
 
 module BNFC.Backend.CPP.STL.CFtoSTLAbs (cf2CPPAbs) where
 
-import Data.List        ( intercalate, intersperse )
+import Data.List        ( intercalate )
 
 import BNFC.Backend.Common.OOAbstract
 import BNFC.CF
@@ -139,7 +139,7 @@ prCon (c,(f,cs)) = unlines [
   "};"
   ]
  where
-   conargs = concat $ intersperse ", "
+   conargs = intercalate ", "
      [x +++ pointerIf st ("p" ++ show i) | ((x,st,_),i) <- zip cs [1::Int ..]]
 
 prList :: (String, Bool) -> String

--- a/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
+++ b/source/src/BNFC/Backend/CPP/STL/CFtoSTLAbs.hs
@@ -265,7 +265,7 @@ prCopyC (c,cs) = unlines [
   "}"
   ]
  where
-   cloneIf st cv = if st then (cv ++ "->clone()") else cv
+   cloneIf st cv = if st then cv ++ "->clone()" else cv
 
 --The destructor deletes all a class's members.
 prDestructorC :: CAbsRule -> String

--- a/source/src/BNFC/Backend/Haskell.hs
+++ b/source/src/BNFC/Backend/Haskell.hs
@@ -147,7 +147,7 @@ distCleanRule opts makeFile = Makefile.mkRule "distclean" ["clean"] $
       , agdaParserFile -- Parser.agda
       , agdaLibFile    -- IOLib.agda
       , agdaMainFile   -- Main.agda
-      , (\ opts -> dir ++ lang opts ++ ".dtd")
+      , \ opts -> dir ++ lang opts ++ ".dtd"
       ]
       -- Files that have no .bak variant
     , map (\ (file, ext) -> mkFile withLang file ext opts)

--- a/source/src/BNFC/Backend/Haskell/CFtoHappy.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoHappy.hs
@@ -4,7 +4,6 @@
 
 -}
 
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module BNFC.Backend.Haskell.CFtoHappy (cf2Happy, convert) where

--- a/source/src/BNFC/Backend/HaskellGADT/CFtoAbstractGADT.hs
+++ b/source/src/BNFC/Backend/HaskellGADT/CFtoAbstractGADT.hs
@@ -127,7 +127,7 @@ prCompos cf =
     prComposCons c
         | isRecursive c = [consFun c +++ unwords (map snd (consVars c)) +++ "->" +++ rhs c]
         | otherwise = []
-    isRecursive c = any (isTreeType cf) (map fst (consVars c))
+    isRecursive c = any (isTreeType cf . fst) (consVars c)
     rhs c = "r" +++ consFun c +++ unwords (map prRec (consVars c))
       where prRec (cat,var) | not (isTreeType cf cat) = "`a`" +++ "r" +++ var
                             | isList cat = "`a` P.foldr (\\ x z -> r (:) `a` f x `a` z) (r [])" +++ var

--- a/source/src/BNFC/Backend/Java.hs
+++ b/source/src/BNFC/Backend/Java.hs
@@ -126,7 +126,7 @@ makeJava' options@Options{..} cf = do
     parsefun     = cf2parse $ parser parselexspec
     parmake      = makeparserdetails (parser parselexspec)
     lexmake      = makelexerdetails  (lexer parselexspec)
-    rp           = (Options.linenumbers options)
+    rp           = Options.linenumbers options
     commentWithEmacsModeHint = comment . ("-*- Java -*- " ++)
 
 makefile ::  FilePath -> FilePath -> [String] -> ParserLexerSpecification -> String -> Doc
@@ -240,15 +240,15 @@ data JavaTestParams = JavaTestParams
       -- ^ List of imported packages.
   , jtpErr                :: String
       -- ^ Name of the exception thrown in case of parsing failure.
-  , jtpErrHand            :: (String -> [Doc])
+  , jtpErrHand            :: String -> [Doc]
       -- ^ Handler for the exception thrown.
-  , jtpLexerConstruction  :: (Doc -> Doc -> Doc)
+  , jtpLexerConstruction  :: Doc -> Doc -> Doc
       -- ^ Function formulating the construction of the lexer object.
-  , jtpParserConstruction :: (Doc -> Doc -> Doc)
+  , jtpParserConstruction :: Doc -> Doc -> Doc
       -- ^ As above, for parser object.
-  , jtpShowAlternatives   :: ([Cat] -> [Doc])
+  , jtpShowAlternatives   :: [Cat] -> [Doc]
       -- ^ Pretty-print the names of the methods corresponding to entry points to the user.
-  , jtpInvocation         :: (Doc -> Doc -> Doc -> Doc -> Doc)
+  , jtpInvocation         :: Doc -> Doc -> Doc -> Doc -> Doc
       -- ^ Function formulating the invocation of the parser tool within Java.
   , jtpErrMsg             :: String
       -- ^ Error string output in consequence of a parsing failure.

--- a/source/src/BNFC/Backend/Java/CFtoJLex15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJLex15.hs
@@ -51,12 +51,12 @@ prelude jflex rp packageBase = vcat
     , "%%"
     , "%cup"
     , "%unicode"
-    , (if rp == RecordPositions
+    , if rp == RecordPositions
       then vcat
         [ "%line"
-        , (if jflex == JFlexCup then "%column" else "")
+        , if jflex == JFlexCup then "%column" else ""
         , "%char" ]
-      else "")
+      else ""
     , "%public"
     , "%{"
     , nest 2 $ vcat
@@ -74,9 +74,9 @@ prelude jflex rp packageBase = vcat
         , "}"
         , "public ComplexSymbolFactory.Location right_loc() {"
         , "  ComplexSymbolFactory.Location left = left_loc();"
-        , (if rp == RecordPositions
+        , if rp == RecordPositions
             then "return new ComplexSymbolFactory.Location(left.getLine(), left.getColumn()+yylength(), left.getOffset()+yylength());"
-            else "return left;")
+            else "return left;"
         , "}"
         , "public String buff()" <+> braces
             (if jflex == JFlexCup

--- a/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoJavaAbs15.hs
@@ -308,7 +308,7 @@ prAssigns [] _ = []
 prAssigns _ [] = []
 prAssigns ((t,n,nm):vs) (p:ps) =
  if n == 1 then
-  case findIndices (\x -> case x of (l,_,_) -> l == t) vs of
+  case findIndices (\(l,_,_) -> l == t) vs of
     [] -> varName nm +++ "=" +++ p ++ ";" +++ prAssigns vs ps
     _ -> varName nm ++ showNum n +++ "=" +++ p ++ ";" +++ prAssigns vs ps
  else varName nm ++ showNum n +++ "=" +++ p ++ ";" +++ prAssigns vs ps

--- a/source/src/BNFC/Backend/Java/CFtoVisitSkel15.hs
+++ b/source/src/BNFC/Backend/Java/CFtoVisitSkel15.hs
@@ -14,7 +14,6 @@
 
 -}
 
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module BNFC.Backend.Java.CFtoVisitSkel15 (cf2VisitSkel) where

--- a/source/src/BNFC/Backend/Latex.hs
+++ b/source/src/BNFC/Backend/Latex.hs
@@ -112,7 +112,7 @@ prtIdentifiers =
 
 prtLiterals :: String -> CF -> String
 prtLiterals _ cf =
-  unlines . concat . List.intersperse [""] . map stringLit . filter (/= catIdent) $ literals cf
+  unlines . List.intercalate [""] . map stringLit . filter (/= catIdent) $ literals cf
 
 stringLit :: TokenCat -> [String]
 stringLit = \case

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlAbs.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlAbs.hs
@@ -14,7 +14,7 @@ import Text.PrettyPrint
 
 import BNFC.CF
 import BNFC.Utils ( (+++), unless, parensIf )
-import Data.List  ( intersperse )
+import Data.List  ( intercalate, intersperse )
 import BNFC.Backend.OCaml.OCamlUtil
 
 -- to produce an OCaml module
@@ -65,7 +65,7 @@ mutualRecDefs ss = case ss of
 prData :: Data -> String
 prData (cat,rules) =
   fixType cat +++ "=\n   " ++
-  concat (intersperse "\n | " (map prRule rules)) ++
+  intercalate "\n | " (map prRule rules) ++
   "\n"
 
 prRule :: (String, [Cat]) -> String

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
@@ -248,7 +248,7 @@ parenth ss = ["("] ++ ss ++ [")"]
 class Print a where
   prt :: Int -> a -> [String]
   prtList :: [a] -> [String]
-  prtList = concat . map (prt 0)
+  prtList = concatMap (prt 0)
 
 instance Print a => Print [a] where
   prt _ = prtList

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlLex.hs
@@ -89,7 +89,7 @@ hashtables cf =
   ht table syms = unless (null syms) $
     [ unwords [ "let", table, "= Hashtbl.create", show (length syms)                  ]
     , unwords [ "let _ = List.iter (fun (kwd, tok) -> Hashtbl.add", table, "kwd tok)" ]
-    , concat  [ "                  [", concat (List.intersperse ";" keyvals), "]"     ]
+    , concat  [ "                  [", List.intercalate ";" keyvals, "]"     ]
     ]
     where
     keyvals = map (\ s -> concat [ "(", mkEsc s, ", ", terminal cf s, ")" ]) syms

--- a/source/src/BNFC/Backend/OCaml/CFtoOCamlYacc.hs
+++ b/source/src/BNFC/Backend/OCaml/CFtoOCamlYacc.hs
@@ -221,7 +221,7 @@ generatePatterns terminal r = case rhsRule r of
    mkIt i = case i of
      Left c -> nonterminal c
      Right s -> terminal s
-   metas its = [ ('$': show i) | (i, Left _c) <- zip [1 ::Int ..] its ]
+   metas its = [ '$': show i | (i, Left _c) <- zip [1 ::Int ..] its ]
 
 specialRules :: CF -> [String]
 specialRules cf = (`map` literals cf) $ \case

--- a/source/src/BNFC/CF.hs
+++ b/source/src/BNFC/CF.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
 
 {-
     BNF Converter: Abstract syntax

--- a/source/src/BNFC/PrettyPrint.hs
+++ b/source/src/BNFC/PrettyPrint.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/source/src/BNFC/TypeChecker.hs
+++ b/source/src/BNFC/TypeChecker.hs
@@ -190,7 +190,7 @@ buildSignature rules = do
 buildContext :: CF -> Context
 buildContext cf = Ctx
     { ctxLabels = cfgSignature cf
-    , ctxTokens = ("Ident" : tokenNames cf)
+    , ctxTokens = "Ident" : tokenNames cf
     , ctxLocals = []
     }
 

--- a/source/src/BNFC/TypeChecker.hs
+++ b/source/src/BNFC/TypeChecker.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- | Type checker for defined syntax constructors @define f xs = e@.
 


### PR DESCRIPTION
Simplify code by removing redundant elements (e.g., brackets, `$`), replacing several compositions with (faster) standard functions intended to have the same effect, etc.