### PR TITLE
Preliminary implementation of a tree-sitter backend

### DIFF
--- a/source/BNFC.cabal
+++ b/source/BNFC.cabal
@@ -264,6 +264,11 @@ library
     -- Agda backend
     BNFC.Backend.Agda
 
+    -- Tree-sitter backend
+    BNFC.Backend.TreeSitter
+    BNFC.Backend.TreeSitter.CFtoTreeSitter
+    BNFC.Backend.TreeSitter.RegToJSReg
+
 ----- Testing --------------------------------------------------------------
 
 test-suite unit-tests

--- a/source/main/Main.hs
+++ b/source/main/Main.hs
@@ -25,6 +25,7 @@ import BNFC.Backend.Java
 import BNFC.Backend.Latex
 import BNFC.Backend.OCaml
 import BNFC.Backend.Pygments
+import BNFC.Backend.TreeSitter
 import BNFC.CF (CF)
 import BNFC.GetCF
 import BNFC.Options hiding (make, Backend)
@@ -81,3 +82,4 @@ maketarget = \case
     TargetOCaml        -> makeOCaml
     TargetPygments     -> makePygments
     TargetCheck        -> error "impossible"
+    TargetTreeSitter   -> makeTreeSitter

--- a/source/src/BNFC/Backend/TreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter.hs
@@ -1,0 +1,32 @@
+{-
+    BNF Converter: TreeSitter Grammar Generator
+    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
+                                 Bjorn Bringert
+
+    Description   : This module generates the grammar.js input file for
+                    tree-sitter.
+
+    Author        : Kangjing Huang (huangkangjing@gmail.com)
+    Created       : 23 Nov, 2023
+
+-}
+
+module BNFC.Backend.TreeSitter where
+
+import BNFC.Backend.Base
+import BNFC.Backend.TreeSitter.CFtoTreeSitter (cfToTreeSitter)
+import BNFC.CF
+import BNFC.Options hiding (Backend)
+import BNFC.PrettyPrint
+
+-- | Entry point: create grammar.js file
+makeTreeSitter :: SharedOptions -> CF -> Backend
+makeTreeSitter opts cf = do
+  mkfile "grammar.js" comment (render $ cfToTreeSitter name cf)
+  where
+    name = lang opts
+
+comment :: String -> String
+comment = ("// " ++)
+
+-- | TODO: Add Makefile generation for tree-sitter

--- a/source/src/BNFC/Backend/TreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module generates the grammar.js input file for
                     tree-sitter.

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module converts BNFC grammar to the contents of a
                     tree-sitter grammar.js file

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -1,0 +1,245 @@
+{-
+    BNF Converter: TreeSitter Grammar Generator
+    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
+                                 Bjorn Bringert
+
+    Description   : This module converts BNFC grammar to the contents of a
+                    tree-sitter grammar.js file
+
+    Author        : Kangjing Huang (huangkangjing@gmail.com)
+    Created       : 08 Nov, 2023
+
+-}
+{-# LANGUAGE BlockArguments #-}
+
+module BNFC.Backend.TreeSitter.CFtoTreeSitter where
+
+import BNFC.Abs (Reg (RSeq, RSeqs, RStar, RAny))
+import BNFC.Backend.TreeSitter.RegToJSReg
+import BNFC.CF
+import BNFC.Lexing (mkRegMultilineComment)
+import BNFC.PrettyPrint
+import Prelude hiding ((<>))
+
+-- | Indent one level of 2 spaces
+indent :: Doc -> Doc
+indent = nest 2
+
+-- | Create content of grammar.js file
+cfToTreeSitter :: String -> CF -> Doc
+cfToTreeSitter name cf =
+  -- Overall structure of grammar.js
+  text "module.exports = grammar({"
+    $+$ indent
+      ( text "name: '" <> text name <> text "',"
+          $+$ extrasSection
+          $+$ wordSection
+          $+$ rulesSection
+      )
+    $+$ text "});"
+  where
+    extrasSection = prExtras cf
+    wordSection = prWord cf
+    rulesSection =
+      text "rules: {"
+        $+$ indent
+          ( prRules cf
+              $+$ prUsrTokenRules cf
+              $+$ prBuiltinTokenRules cf
+          )
+        $+$ text "},"
+
+-- | Print rules for comments
+prExtras :: CF -> Doc
+prExtras cf =
+  if extraNeeded
+    then
+      defineSymbol "extras" <> "["
+        $+$ indent
+          ( -- default rule for white spaces
+            text "/\\s/,"
+              $+$ mRules
+              $+$ sRules
+          )
+        $+$ text "],"
+    else empty
+  where
+    extraNeeded = length commentMRules + length commentSRules > 0
+    (commentMRules, commentSRules) = comments cf
+    mRules = vcat' $ map mkOneMRule commentMRules
+    sRules = vcat' $ map mkOneSRule commentSRules
+    mkOneSRule s = text (printRegJSReg $ RSeq (RSeqs s) (RStar RAny)) <> text ","
+    mkOneMRule (s, e) = text (printRegJSReg $ mkRegMultilineComment s e) <> text ","
+
+-- | Print word section, this section is needed for tree-sitter
+--   to do keyword extraction before any parsing/lexing, see
+--   https://tree-sitter.github.io/tree-sitter/creating-parsers#keyword-extraction
+--   TODO: currently, we just add every user defined token as well
+--   as the predefined Ident token to this list to be safe. Ideally,
+--   we should enumerate all defined tokens against all occurrences of
+--   keywords. Any tokens patterns that could accept a keyword will go
+--   into this list. This will require integration of a regex engine.
+prWord :: CF -> Doc
+prWord cf =
+  if wordNeeded
+    then
+      defineSymbol "word"
+        $+$ indent
+          ( wrapChoice
+              ( usrTokensFormatted
+                  ++ [text "$.token_Ident" | identUsed]
+              )
+          )
+          <> ","
+    else empty
+  where
+    wordNeeded = identUsed || usrTokens /= []
+    identUsed = isUsedCat cf (TokenCat catIdent)
+    usrTokens = tokenPragmas cf
+    usrTokensFormatted =
+      map (text . refName . formatCatName False . TokenCat . fst) $ usrTokens
+
+-- | Print builtin token rules according to their usage
+prBuiltinTokenRules :: CF -> Doc
+prBuiltinTokenRules cf =
+  ifC catInteger integerRule
+    $+$ ifC catDouble doubleRule
+    $+$ ifC catChar charRule
+    $+$ ifC catString stringRule
+    $+$ ifC catIdent identRule
+  where
+    ifC cat d = if isUsedCat cf (TokenCat cat) then d else empty
+
+-- | Predefined builtin token rules
+integerRule, doubleRule, charRule, stringRule, identRule :: Doc
+integerRule = defineSymbol "token_Integer" <+> text "/\\d+/" <> ","
+doubleRule = defineSymbol "token_Double" <+> text "/\\d+\\.\\d+(e-?\\d+)?/" <> ","
+charRule =
+  defineSymbol "token_Char" <+> text "/'([^'\\\\]|(\\\\[\"'\\\\tnrf]))'/" <> ","
+stringRule =
+  defineSymbol "token_String" <+> text "/\"([^'\\\\]|(\\\\[\"'\\\\tnrf]))*\"/" <> ","
+identRule =
+  defineSymbol "token_Ident" <+> text "/[a-zA-Z][a-zA-Z\\d_']*/" <> ","
+
+-- | First print the entrypoint rule, tree-sitter always use the
+--   first rule as entrypoint and does not support multi-entrypoint.
+--   Then print rest of the rules
+prRules :: CF -> Doc
+prRules cf =
+  if onlyOneEntry
+    then
+      prOneCat entryRules entryCat
+        $+$ prOtherRules entryCat cf
+    else error "Tree-sitter only supports one entrypoint"
+  where
+    --If entrypoint is defined, there must be only one entrypoint
+    --If it is not defined, defaults to use the first rule as entrypoint
+    onlyOneEntry = not (hasEntryPoint cf) || onlyOneEntryDefined
+    onlyOneEntryDefined = length (allEntryPoints cf) == 1
+    entryCat = firstEntry cf
+    entryRules = rulesForCat' cf entryCat
+
+-- | Print all other rules except the entrypoint
+prOtherRules :: Cat -> CF -> Doc
+prOtherRules entryCat cf = vcat' $ map mkOne rules
+  where
+    rules = [(c, r) | (c, r) <- ruleGroupsInternals cf, c /= entryCat]
+    mkOne (cat, rules) = prOneCat rules cat
+
+prUsrTokenRules :: CF -> Doc
+prUsrTokenRules cf = vcat' $ map prOneToken tokens
+  where
+    tokens = tokenPragmas cf
+
+-- | Check if a set of rules contains internal rules
+hasInternal :: [Rule] -> Bool
+hasInternal = not . all isParsable
+
+-- | Generates one or two tree-sitter rule(s) for one non-terminal from CF.
+-- Uses choice function from tree-sitter to combine rules for the non-terminal
+-- If the non-terminal has internal rules, an internal version of the non-terminal
+-- will be created (prefixed with "_" in tree-sitter), and all internal rules will
+-- be sectioned as such.
+prOneCat :: [Rule] -> NonTerminal -> Doc
+prOneCat rules nt =
+  defineSymbol (formatCatName False nt)
+    $+$ indent (appendComma parRhs)
+    $+$ internalRules
+  where
+    int = hasInternal rules
+    internalRules =
+      if int
+        then defineSymbol (formatCatName True nt) $+$ indent (appendComma intRhs)
+        else empty
+    parRhs = wrapChoice $ transChoice ++ genChoice (filter isParsable rules)
+    transChoice = [text $ refName $ formatCatName True nt | int]
+    intRhs = wrapChoice $ genChoice (filter (not . isParsable) rules)
+    genChoice = map (wrapSeq . formatRhs . rhsRule)
+
+-- | Generate one tree-sitter rule for one defined token
+prOneToken :: (TokenCat, Reg) -> Doc
+prOneToken (cat, exp) =
+  defineSymbol (formatCatName False $ TokenCat cat)
+    $+$ indent (text $ printRegJSReg exp) <> ","
+
+-- | Start a defined symbol block in tree-sitter grammar
+defineSymbol :: String -> Doc
+defineSymbol name = hsep [text name <> ":", text "$", text "=>"]
+
+appendComma :: Doc -> Doc
+appendComma = (<> text ",")
+
+commaJoin :: Bool -> [Doc] -> Doc
+commaJoin newline =
+  foldl comma empty
+  where
+    comma a b
+      | isEmpty a = b
+      | isEmpty b = a
+      | otherwise = (if newline then ($+$) else (<>)) (a <> ",") b
+
+wrapSeq :: [Doc] -> Doc
+wrapSeq = wrapOptListFun "seq" False
+
+wrapChoice :: [Doc] -> Doc
+wrapChoice = wrapOptListFun "choice" True
+
+-- | Wrap list using tree-sitter fun if the list contains multiple items
+-- Returns the only item without wrapping otherwise
+wrapOptListFun :: String -> Bool -> [Doc] -> Doc
+wrapOptListFun fun newline list =
+  if length list == 1
+    then head list
+    else wrapFun fun newline (commaJoin newline list)
+
+wrapFun :: String -> Bool -> Doc -> Doc
+wrapFun fun newline arg = joinOp [text fun <> text "(", indent arg, text ")"]
+  where
+    joinOp = if newline then vcat' else hcat
+
+-- | Helper for referring to non-terminal names in tree-sitter
+refName :: String -> String
+refName = ("$." ++)
+
+-- | Format right hand side into list of strings
+formatRhs :: SentForm -> [Doc]
+formatRhs =
+  map \case
+    Left c -> text $ refName $ formatCatName False c
+    Right term -> quoted term
+
+quoted :: String -> Doc
+quoted s = text "\"" <> text s <> text "\""
+
+-- | Format string for cat name, prefix "_" if the name is for internal rules
+formatCatName :: Bool -> Cat -> String
+formatCatName internal c =
+  if internal
+    then "_" ++ formatted
+    else formatted
+  where
+    formatted = formatName c
+    formatName (Cat name) = name
+    formatName (TokenCat name) = "token_" ++ name
+    formatName (ListCat c) = "list_" ++ formatName c
+    formatName (CoercCat name i) = name ++ show i

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -10,7 +10,6 @@
     Created       : 08 Nov, 2023
 
 -}
-{-# LANGUAGE BlockArguments #-}
 
 module BNFC.Backend.TreeSitter.CFtoTreeSitter where
 
@@ -224,9 +223,9 @@ refName = ("$." ++)
 -- | Format right hand side into list of strings
 formatRhs :: SentForm -> [Doc]
 formatRhs =
-  map \case
+  map (\case
     Left c -> text $ refName $ formatCatName False c
-    Right term -> quoted term
+    Right term -> quoted term)
 
 quoted :: String -> Doc
 quoted s = text "\"" <> text s <> text "\""

--- a/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
+++ b/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
@@ -10,7 +10,7 @@
 -}
 {-# LANGUAGE LambdaCase #-}
 
-module BNFC.Backend.TreeSitter.RegToJSReg (printRegJSReg) where
+module BNFC.Backend.TreeSitter.RegToJSReg (printRegJSReg, escapeCharFrom) where
 
 import BNFC.Abs
 

--- a/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
+++ b/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
@@ -1,0 +1,94 @@
+{-
+    BNF Converter: TreeSitter Grammar Generator
+    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
+                                 Bjorn Bringert
+
+    Description   : This module converts BNFC Reg to Javascript regular
+                    expressions that is used in
+
+    Author        : Kangjing Huang (huangkangjing@gmail.com)
+    Created       : 23 Nov, 2023
+
+-}
+{-# LANGUAGE LambdaCase #-}
+
+module BNFC.Backend.TreeSitter.RegToJSReg (printRegJSReg) where
+
+import BNFC.Abs
+
+printRegJSReg :: Reg -> String
+printRegJSReg r = "/" ++ render (prt 0 r) ++ "/"
+
+-- There is no space-based formatting for javascript regex
+-- We just concat everything together
+render :: [String] -> String
+render = concat
+
+parenth :: [String] -> [String]
+parenth s = ["("] ++ s ++ [")"]
+
+-- Printer class
+class Print a where
+  prt :: Int -> a -> [String]
+
+prPrec :: Int -> Int -> [String] -> [String]
+prPrec i j = if i > j then parenth else id
+
+-- | reserved characters for Javascript regex format, sourced from
+--   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping
+reserved :: String
+reserved = ".*+?^${}()|[]\\/"
+
+-- | reserved characters for alt expressions in Javascript regex format
+reservedAlt :: String
+reservedAlt = "^[]-\\/"
+
+-- | Pattern for matching empty string in Javascript regex format
+emptyPat :: String
+emptyPat = " [^\\u0000-\\uFFFF]?"
+
+-- | escape character according to Javascript regex format
+escapeCharFrom :: String -> Char -> String
+escapeCharFrom reservedChars x
+  | x `elem` reservedChars = '\\' : [x]
+  | otherwise = [x]
+
+escapeChar :: Char -> String
+escapeChar = escapeCharFrom reserved
+
+escapeStr :: String -> String
+escapeStr = concatMap escapeChar
+
+escapeCharAlt :: Char -> String
+escapeCharAlt = escapeCharFrom reservedAlt
+
+escapeStrAlt :: String -> String
+escapeStrAlt = concatMap escapeChar
+
+instance Print Identifier where
+  prt _ (Identifier (_, i)) = [i]
+
+instance Print Reg where
+  prt i = \case
+    RSeq reg0 reg -> prPrec i 2 $ prt 2 reg0 ++ prt 3 reg
+    RAlt reg0 reg -> prPrec i 1 $ prt 1 reg0 ++  ["|"] ++ prt 2 reg
+    -- Javascript regex does not support general set difference
+    RMinus reg0 REps -> prt i reg0 -- REps is identity for difference
+    RMinus RAny (RChar c) -> ["[^" ++ escapeCharAlt c ++ "]"]
+    RMinus RAny (RAlts s) -> ["[^" ++ escapeStrAlt s ++ "]"]
+    -- TODO: It is possible to use external scanners in tree-sitter:
+    -- https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners
+    -- to support general set differences in the future
+    RMinus _ _ -> error "Javascript regex does not support general set differences"
+    RStar reg -> prt 3 reg ++ ["*"]
+    RPlus reg -> prt 3 reg ++ ["+"]
+    ROpt reg -> prt 3 reg ++ ["?"]
+    REps -> [emptyPat]
+    RChar c -> [escapeChar c]
+    RAlts str -> ["[" ++ escapeStrAlt str ++ "]"]
+    RSeqs str -> [escapeStr str]
+    RDigit -> ["\\d"]
+    RLetter -> ["[a-zA-Z]"]
+    RUpper -> ["[A-Z]"]
+    RLower -> ["[a-z]"]
+    RAny -> ["."]

--- a/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
+++ b/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module converts BNFC Reg to Javascript regular
                     expressions that is used in

--- a/source/src/BNFC/CF.hs
+++ b/source/src/BNFC/CF.hs
@@ -783,6 +783,9 @@ hasPositionTokens cf = or [ b | TokenReg _ b _ <- cfgPragmas cf ]
 isPositionCat :: CFG f -> TokenCat -> Bool
 isPositionCat cf cat = or [ b | TokenReg name b _ <- cfgPragmas cf, wpThing name == cat]
 
+-- | Is there a explicitly defined @entrypoint@ pragma?
+hasEntryPoint :: CFG f -> Bool
+hasEntryPoint cf = or [ True | EntryPoints{} <- cfgPragmas cf]
 
 -- | Categories that are entry points to the parser.
 --

--- a/source/src/BNFC/Options.hs
+++ b/source/src/BNFC/Options.hs
@@ -63,6 +63,7 @@ data Mode
 data Target = TargetC | TargetCpp | TargetCppNoStl
             | TargetHaskell | TargetHaskellGadt | TargetLatex
             | TargetJava | TargetOCaml | TargetPygments
+            | TargetTreeSitter
             | TargetCheck
   deriving (Eq, Bounded, Enum, Ord)
 
@@ -80,6 +81,7 @@ instance Show Target where
   show TargetJava         = "Java"
   show TargetOCaml        = "OCaml"
   show TargetPygments     = "Pygments"
+  show TargetTreeSitter   = "Tree-sitter"
   show TargetCheck        = "Check LBNF file"
 
 -- | Which version of Alex is targeted?
@@ -258,6 +260,7 @@ printTargetOption = ("--" ++) . \case
   TargetJava        -> "java"
   TargetOCaml       -> "ocaml"
   TargetPygments    -> "pygments"
+  TargetTreeSitter  -> "tree-sitter"
   TargetCheck       -> "check"
 
 printAlexOption :: AlexVersion -> String
@@ -309,6 +312,8 @@ targetOptions =
     "Output OCaml code for use with ocamllex and menhir (short for --ocaml --menhir)"
   , Option "" ["pygments"]      (NoArg (\o -> o {target = TargetPygments}))
     "Output a Python lexer for Pygments"
+  , Option "" ["tree-sitter"]   (NoArg (\o -> o {target = TargetTreeSitter}))
+    "Output grammar.js file for use with tree-sitter"
   , Option "" ["check"]         (NoArg (\ o -> o{target = TargetCheck }))
     "No output. Just check input LBNF file"
   ]
@@ -524,6 +529,7 @@ instance Maintained Target where
     TargetJava        -> True
     TargetOCaml       -> True
     TargetPygments    -> True
+    TargetTreeSitter  -> True
     TargetCheck       -> True
 
 instance Maintained AlexVersion where

--- a/source/test/BNFC/Backend/TreeSitterSpec.hs
+++ b/source/test/BNFC/Backend/TreeSitterSpec.hs
@@ -1,0 +1,25 @@
+module BNFC.Backend.TreeSitterSpec where
+
+import BNFC.Options
+import BNFC.GetCF
+
+import Test.Hspec
+import BNFC.Hspec
+
+import BNFC.Backend.TreeSitter -- SUT
+
+calcOptions = defaultOptions { lang = "Calc" }
+getCalc = parseCF  calcOptions TargetTreeSitter $
+  unlines [ "EAdd. Exp ::= Exp \"+\" Exp1  ;"
+          , "ESub. Exp ::= Exp \"-\" Exp1  ;"
+          , "EMul. Exp1  ::= Exp1  \"*\" Exp2  ;"
+          , "EDiv. Exp1  ::= Exp1  \"/\" Exp2  ;"
+          , "EInt. Exp2  ::= Integer ;"
+          , "coercions Exp 2 ;" ]
+
+spec = do
+
+  describe "Tree-Sitter backend" $ do
+    it "creates the grammar.js file" $ do
+      calc <- getCalc
+      makeTreeSitter calcOptions calc `shouldGenerate` "grammar.js"

--- a/testing/src/ParameterizedTests.hs
+++ b/testing/src/ParameterizedTests.hs
@@ -419,6 +419,7 @@ parameters = concat
     , javaParams { tpName = "Java (with jflex and line numbers)"
                  , tpBnfcOptions = ["--java", "--jflex", "-l"] }
     ]
+  , [ treeSitter ]
   ]
   where
     base = baseParameters
@@ -441,6 +442,14 @@ parameters = concat
         , tpBuild       = tpMake ["OCAMLCFLAGS=-safe-string"]
         , tpBnfcOptions = ["--ocaml"]
         , tpRunTestProg = haskellRunTestProg
+        }
+    treeSitter = TP
+        { tpName        = "tree-sitter"
+        , tpBuild       = do
+            cmd "tree-sitter" "generate" . (:[]) =<< findFile "grammar.js"
+        , tpBnfcOptions = ["--tree-sitter"]
+        , tpRunTestProg = \ _lang args -> do
+            cmd "tree-sitter" "parse" args
         }
 
 -- | Helper function that runs bnfc with the context's options and an


### PR DESCRIPTION
Generates `grammar.js` file that could be used with [tree-sitter](https://tree-sitter.github.io/tree-sitter/) to generate parsers with many different languages. Most of the functionalities of BNFC should be already implemented and working.

There are two remaining issues/features that are not implemented yet:

1. `tree-sitter` does not distinguish between a lexer and a parser, this created issues in their keyword recognition (documented [here](https://tree-sitter.github.io/tree-sitter/creating-parsers#keywords)). They use a keyword extraction mechanism to list token rules that could accept a keyword explicitly. 
    The only way to do this cleanly from the BNFC side is to run all user-defined token patterns against all keywords in the input grammar to determine which patterns should be listed to do keyword extraction. Unfortunately, there are no regex facilities in BNFC to do this currently and an external regex engine is needed. 
    This branch currently just puts all user-defined token patterns into the keyword extraction list for safety. The performance impact of such practice is unknown. How should BNFC approach this problem should be discussed further.
2. Like many other lexers, the regular expression used by `tree-sitter` does not support general set differences. However, `tree-sitter` supports a mechanism known as [external scanners](https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners) that could be used to implement this. This is not implemented yet.

These are documented in the source code using `TODO` comments as well.

Should help #193 and #394