### PR TITLE
Removal of zero-width matches in generated tree-sitter grammar files, preliminary implementation

### DIFF
--- a/source/src/BNFC/Backend/TreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter.hs
@@ -20,11 +20,13 @@ import BNFC.PrettyPrint
 -- | Entry point: create grammar.js file
 makeTreeSitter :: SharedOptions -> CF -> Backend
 makeTreeSitter opts cf = do
-  mkfile "grammar.js" comment (render $ cfToTreeSitter name cf)
+  -- Always remove zero width match for now, if needed, can be changed
+  -- to remove on flag in the future
+  mkfile "grammar.js" comment (render $ cfToTreeSitter name cf True)
   where
     name = lang opts
 
 comment :: String -> String
 comment = ("// " ++)
 
--- | TODO: Add Makefile generation for tree-sitter
+-- TODO: Add Makefile generation for tree-sitter

--- a/source/src/BNFC/Backend/TreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module generates the grammar.js input file for
                     tree-sitter.

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -188,7 +188,9 @@ instance FormatRule RuleOpt where
 analyzeCF :: CF -- ^ Context-free grammar of the language
   -> Cat -- ^ Category object for the entrance symbol
   -> ([(Cat, [Rule])], [Rule]) -- ^ (groups of remaining categories and rules, entrance rules)
-analyzeCF _ _ = ([], [])
+analyzeCF cf entryCat = ([(c, rulesForCat' cf c)| c <- allCats, c /= entryCat],
+  rulesForCat' cf entryCat)
+  where allCats = reallyAllCats cf
 
 -- | Analyzes the grammar with the entrance symbol.
 -- This version of analyze function performs zero-width match analysis on all symbols and

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -22,7 +22,7 @@ import BNFC.PrettyPrint
 
 import Prelude hiding ((<>))
 import qualified Data.Map as Map
-import Data.Map (Map)
+import Data.Map ()
 
 -- | Indent one level of 2 spaces
 indent :: Doc -> Doc

--- a/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
+++ b/source/src/BNFC/Backend/TreeSitter/CFtoTreeSitter.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module converts BNFC grammar to the contents of a
                     tree-sitter grammar.js file

--- a/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
+++ b/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
@@ -10,7 +10,7 @@
 -}
 {-# LANGUAGE LambdaCase #-}
 
-module BNFC.Backend.TreeSitter.RegToJSReg (printRegJSReg) where
+module BNFC.Backend.TreeSitter.RegToJSReg (printRegJSReg, escapeCharFrom) where
 
 import BNFC.Abs
 

--- a/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
+++ b/source/src/BNFC/Backend/TreeSitter/RegToJSReg.hs
@@ -1,7 +1,5 @@
 {-
     BNF Converter: TreeSitter Grammar Generator
-    Copyright (C) 2004  Author:  Markus Forsberg, Michael Pellauer,
-                                 Bjorn Bringert
 
     Description   : This module converts BNFC Reg to Javascript regular
                     expressions that is used in

--- a/testing/src/ParameterizedTests.hs
+++ b/testing/src/ParameterizedTests.hs
@@ -419,6 +419,7 @@ parameters = concat
     , javaParams { tpName = "Java (with jflex and line numbers)"
                  , tpBnfcOptions = ["--java", "--jflex", "-l"] }
     ]
+  , [ treeSitter ]
   ]
   where
     base = baseParameters
@@ -441,6 +442,14 @@ parameters = concat
         , tpBuild       = tpMake ["OCAMLCFLAGS=-safe-string"]
         , tpBnfcOptions = ["--ocaml"]
         , tpRunTestProg = haskellRunTestProg
+        }
+    treeSitter = TP
+        { tpName        = "tree-sitter"
+        , tpBuild       = do
+            cmd "tree-sitter" "generate" . (:[]) =<< findFile "grammar.js"
+        , tpBnfcOptions = ["--tree-sitter"]
+        , tpRunTestProg = \ _lang args -> do
+            cmd "tree-sitter" "parse" args
         }
 
 -- | Helper function that runs bnfc with the context's options and an


### PR DESCRIPTION
Tree-sitter has a known limitation of not handling symbols that can match zero-width (a.k.a. "empty") strings. (Documented [here](https://github.com/tree-sitter/tree-sitter/blob/ff89b539f276e2bd19248ffa462d8a426341993d/cli/src/generate/prepare_grammar/flatten_grammar.rs#L199)) The only exception seems to be the start symbol.

However, in BNFC, zero-width matching symbols are supported and used in many examples and test cases. (e.g. The list macros in BNFC) It would be impractical to not support them in the tree-sitter backend.

It is possible to eliminate all zero-width matching symbols from a grammar: First, all symbols that could match zero-width need to be identified. Then these symbols can be converted to valid tree-sitter symbols by removing the RHS empty branches from its rules. Then all rules of the entire grammar need to be processed, wrapping all of the references to the aforementioned symbol with `optional(..)`. Finally since the addition of `optional(..)` can populate zero-width-matching to other symbols, this needs to be done repeatedly until converging on a fixed point or the zero-width-matching is populated to the start symbol.

This PR implements a preliminary version of the above-described algorithm. The converging process is not done yet and currently, it only handles simple cases of zero-width-matching where there is only one layer of matching. It should be sufficient enough for most cases like the list-related internal macros provided in BNFC.