### PR TITLE
Fix #503: Haskell: no longer derive Typeable (obsolete since GHC 7.10)

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * C: preserve case in constructors (union): e.g. label `EInt` now is union member `eInt_` rather than `eint_`
   [[#479](https://github.com/BNFC/bnfc/issues/479)]
+* Haskell: no longer derive `Typeable` (obsolete since GHC 7.10)
+  [[#503](https://github.com/BNFC/bnfc/issues/503)]
 
 # 2.9.5
 

--- a/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
+++ b/source/src/BNFC/Backend/Haskell/CFtoAbstract.hs
@@ -39,15 +39,14 @@ cf2Abstract
   -> CF        -- ^ Grammar.
   -> Doc
 -- tokenText :: TokenText -- ^ Use @ByteString@ or @Text@ instead of @String@?
--- generic   :: Bool      -- ^ Derive @Data@, Generic@, @Typeable@?
+-- generic   :: Bool      -- ^ Derive @Data@ and Generic@?
 -- functor   :: Bool      -- ^ Make the tree a functor?
 cf2Abstract Options{ lang, tokenText, generic, functor } name cf = vsep . concat $
     [ []
 
     -- Modules header
     , [ vcat . concat $
-        [ [ "{-# LANGUAGE DeriveDataTypeable #-}"         | gen ]
-        , [ "{-# LANGUAGE DeriveGeneric #-}"              | gen ]
+        [ [ "{-# LANGUAGE DeriveGeneric #-}"              | gen ]
         , [ "{-# LANGUAGE DeriveTraversable #-}"          | fun ]
         , [ "{-# LANGUAGE FlexibleInstances #-}"          | fun ]
         , [ "{-# LANGUAGE GeneralizedNewtypeDeriving #-}" | hasIdentLikeNoPos ] -- for IsString
@@ -71,8 +70,8 @@ cf2Abstract Options{ lang, tokenText, generic, functor } name cf = vsep . concat
       ]
     , [ vcat . concat $
         [ when hasTextualToks $ map text $ tokenTextImport tokenText
-        , [ "import qualified Data.Data    as C (Data, Typeable)" | gen ]
-        , [ "import qualified GHC.Generics as C (Generic)"        | gen ]
+        , [ "import qualified Data.Data    as C (Data)"    | gen ]
+        , [ "import qualified GHC.Generics as C (Generic)" | gen ]
         ]
       ]
 
@@ -140,7 +139,7 @@ cf2Abstract Options{ lang, tokenText, generic, functor } name cf = vsep . concat
 
     stdClasses = [ "Eq", "Ord", "Show", "Read" ]
     funClasses = [ "Functor", "Foldable", "Traversable" ]
-    genClasses = [ "Data", "Typeable", "Generic" ]
+    genClasses = [ "Data", "Generic" ]
     derivingClasses functor = map ("C." ++) $ concat
       [ stdClasses
       , when functor funClasses

--- a/source/src/BNFC/Options.hs
+++ b/source/src/BNFC/Options.hs
@@ -134,7 +134,7 @@ data SharedOptions = Options
   --- Haskell specific:
   , inDir         :: Bool        -- ^ Option @-d@.
   , functor       :: Bool        -- ^ Option @--functor@.  Make AST functorial?
-  , generic       :: Bool        -- ^ Option @--generic@.  Derive Data, Generic, Typeable?
+  , generic       :: Bool        -- ^ Option @--generic@.  Derive Data and Generic?
   , alexMode      :: AlexVersion -- ^ Options @--alex@.
   , tokenText     :: TokenText   -- ^ Options @--bytestrings@, @--string-token@, and @--text-token@.
   , glr           :: HappyMode   -- ^ Happy option @--glr@.
@@ -378,7 +378,7 @@ specificOptions =
           "Make the AST a functor and use it to store the position of the nodes"
     , haskellTargets )
   , ( Option []    ["generic"] (NoArg (\o -> o {generic = True}))
-          "Derive Data, Generic, and Typeable instances for AST types"
+          "Derive Data and Generic instances for AST types"
     , haskellTargets )
   , ( Option []    ["xml"] (NoArg (\o -> o {xml = 1}))
           "Also generate a DTD and an XML printer"
@@ -660,5 +660,4 @@ translateOldOptions = mapM $ \ o -> do
     , ("-generic"             , "--generic")
     , ("--ghc"                , "--generic")
     , ("--deriveGeneric"      , "--generic")
-    , ("--deriveDataTypeable" , "--generic")
     ]


### PR DESCRIPTION
Closes #503.
