### PR TITLE
fix lex_destroy return type

### DIFF
--- a/source/src/BNFC/Backend/C/CFtoBisonC.hs
+++ b/source/src/BNFC/Backend/C/CFtoBisonC.hs
@@ -137,7 +137,7 @@ header mode cf = unlines $ concat
     , "extern YY_BUFFER_STATE " ++ name ++ "_scan_string(const char *str, yyscan_t scanner);"
     , "extern void " ++ name ++ "_delete_buffer(YY_BUFFER_STATE buf, yyscan_t scanner);"
     , ""
-    , "extern void " ++ name ++ "lex_destroy(yyscan_t scanner);"
+    , "extern int " ++ name ++ "lex_destroy(yyscan_t scanner);"
     , "extern char* " ++ name ++ "get_text(yyscan_t scanner);"
     , ""
     , "extern yyscan_t " ++ name ++ "_initialize_lexer(FILE * inp);"


### PR DESCRIPTION
I noticed that return type of `yylex_destroy` is wrong in `Parser.c`. It was causing weird linking problems for me. This mr fixes it