### PR TITLE
Java: add foldInit to FoldVisitor

### DIFF
--- a/source/CHANGELOG.md
+++ b/source/CHANGELOG.md
@@ -3,6 +3,8 @@
   [[#461](https://github.com/BNFC/bnfc/issues/461)]
 * Haskell: fix incorrect AST when `define`ing labels without argument
   [[#560](https://github.com/BNFC/bnfc/issues/560)]
+* Java: `FoldVisitor` now has an overridable `foldInit` method that receives the
+  current node, generalizing the fold from a catamorphism to a paramorphism
 
 # 2.9.6.3
 

--- a/source/src/BNFC/Backend/Java/CFtoFoldVisitor.hs
+++ b/source/src/BNFC/Backend/Java/CFtoFoldVisitor.hs
@@ -27,6 +27,8 @@ cf2FoldVisitor packageBase packageAbsyn cf =
      "public abstract class FoldVisitor<R,A> implements AllVisitor<R,A> {",
      "    public abstract R leaf(A arg);",
      "    public abstract R combine(R x, R y, A arg);",
+     "    /** Initial fold value at a node. Override to access the node. */",
+     "    public R foldInit(Object p, A arg) { return leaf(arg); }",
      "",
      concatMap (prData packageAbsyn user) groups,
      "}"]
@@ -41,12 +43,16 @@ prData packageAbsyn user (cat, rules) = unlines
     , concatMap (prRule packageAbsyn user cat) rules
     ]
 
---traverses a standard rule.
+--Traverses a standard rule.
+--
+-- >>> prRule "lang.absyn" [] (Cat "B") $ npRule "F" (Cat "B") [Left (Cat "A"), Right "+", Left (ListCat (Cat "B"))] Parsable
+-- "    public R visit(lang.absyn.F p, A arg) {\n      R r = foldInit(p, arg);\n      r = combine(p.a_.accept(this, arg), r, arg);\n      for (lang.absyn.B x : p.listb_)\n      {\n        r = combine(x.accept(this, arg), r, arg);\n      }\n      return r;\n    }\n"
+
 prRule :: String -> [UserDef] -> Cat -> Rule -> String
 prRule packageAbsyn user _ (Rule fun _ cats _)
     | not (isCoercion fun || isDefinedRule fun) = unlines $
   ["    public R visit(" ++ cls ++ " p, A arg) {",
-   "      R r = leaf(arg);"]
+   "      R r = foldInit(p, arg);"]
   ++  map ("      "++) visitVars
   ++ ["      return r;",
       "    }"]


### PR DESCRIPTION
`FoldVisitor` folds over the AST using `leaf(arg)` (as base value) and `combine`. This works well, but sometimes accessing the node itself is useful, this is currently not possible without overriding every single `visit` method.

This PR adds `foldInit(Object p, A arg)`, defaulting to `leaf(arg)` . Visit methods now use `R r = foldInit(p, arg)` instead of `R r = leaf(arg)`. Existing subclasses are unaffected. `foldInit` takes `Object` because AST classes don't share a common base type (a common base type would also be useful, for instance to easily access line numbers, although I am not sure how that would be best implemented).

(This change extends the fold from a [catamorphism](https://en.wikipedia.org/wiki/Catamorphism) to a [paramorphism](https://en.wikipedia.org/wiki/Paramorphism).)

For example, counting AST nodes of a specific type using the proposed extension:

```java
new FoldVisitor<Integer, Void>() {
    public Integer leaf(Void arg) { return 0; }
    public Integer combine(Integer x, Integer r, Void arg) { return x + r; }
    public Integer foldInit(Object p, Void arg) {
        return (p instanceof EInt) ? 1 : 0;
    }
}
```

Without `foldInit`, this requires overriding `visit` for every AST class, because `leaf` only receives `arg`, not the node `p`.

Includes a doctest and a changelog entry.